### PR TITLE
feat: add weather forecast support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,7 +114,7 @@ Use the actual method names from the source code. Key ones that are easy to get 
 - **Live tests:** Require `.env` file with `SENSORLINX_USERNAME`, `SENSORLINX_PASSWORD`, `SENSORLINX_BUILDING_ID`, `SENSORLINX_DEVICE_ID`
 - **Run all unit tests:** `pytest tests/get_parameter_test.py tests/set_parameters_test.py tests/temperature_class_test.py`
 - **Run live tests:** `pytest tests/live_test.py -s -v` (needs network + credentials)
-- **Current test count:** ~669 tests
+- **Current test count:** ~679 tests
 
 ## CI/CD Workflows
 
@@ -149,6 +149,7 @@ The HBX ECO-0600 is a heat pump staging controller for hydronic (water-based) he
 - **Weather Shutdown:** `wwsd` (warm weather) and `cwsd` (cold weather) define outdoor temps at which heating/cooling shuts off entirely.
 - **Stages:** Up to 16 heat pump stages can be managed with configurable lag times, rotation, and sequencing.
 - **Backup:** An auxiliary/backup heat source with its own differential, outdoor temp lockout, and tank temp lockout.
+- **Weather:** Current conditions and forecast are stored at the building level (not device level). Accessed via `get_buildings(building_id)` — the building dict has a `weather.weather` key (current conditions) and `weather.forecast` key (list of periods). Both `get_current_weather()` and `get_forecast()` on `SensorlinxDevice` accept an optional `building_info` dict to avoid redundant API calls. Temperatures in weather data are in °F and are returned as `Temperature` objects.
 - **Demands:** Heat demand (`hd`), cool demand (`cd`), and domestic hot water (`dhw`) are independent demand channels.
 - **Temperature sensors:** Up to 4 sensor inputs (tank, outdoor, and two auxiliary). Accessed via `tB1`–`tB4` (raw) or the `temperatures` array (structured).
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ A high-level wrapper around a single device. All methods are `async`.
 | `get_runtimes()` | `dict` | Stage runtimes as `list[timedelta]`, backup runtime as `timedelta` |
 | `get_heatpump_stages_state()` | `list[dict]` | Stage info with `activated`, `enabled`, `title`, `device`, `index`, `runTime` |
 | `get_backup_state()` | `dict` | Backup state with `activated`, `enabled`, `title`, `runTime` |
+| `get_current_weather()` | `dict` | Current conditions: `temp`, `feelsLike`, `min`, `max` as `Temperature`; `pressure`, `humidity`, `wind`, `windDir`, `clouds`, `snow`, `rain`, `description`, `icon`, `weatherId` |
+| `get_forecast()` | `list[dict]` | Forecast periods: `time` as `datetime`, `temp`/`min`/`max` as `Temperature`, `pop`, `snow`, `description`, `icon`, `weatherId` |
+
+#### Weather conditions
+
+The `description` and `weatherId` fields in weather and forecast data come from [OpenWeatherMap](https://openweathermap.org/weather-conditions). Use `weatherId` for programmatic checks — it is more reliable than parsing the description string.
+
+| Group | `weatherId` range | Example descriptions |
+|---|---|---|
+| Thunderstorm | 200–232 | "thunderstorm with light rain", "heavy thunderstorm" |
+| Drizzle | 300–321 | "light intensity drizzle", "drizzle rain" |
+| Rain | 500–531 | "light rain", "moderate rain", "heavy intensity rain" |
+| Snow | 600–622 | "light snow", "heavy snow", "sleet" |
+| Atmosphere | 701–781 | "mist", "smoke", "haze", "fog", "tornado" |
+| Clear | 800 | "clear sky" |
+| Clouds | 801–804 | "few clouds", "scattered clouds", "broken clouds", "overcast clouds" |
 
 #### Setters
 

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -2190,3 +2190,118 @@ class SensorlinxDevice:
             'title': backup_data.get('title', 'Backup'),
             'runTime': backup_data.get('runTime', '0:00')
         }
+
+    async def get_current_weather(self, building_info: Optional[Dict] = None) -> Dict:
+        """
+        Retrieve the current weather conditions for the building.
+
+        Weather data is attached to the building, not the device.
+
+        Args:
+            building_info (Optional[Dict]): If provided, use this building dict instead of fetching from API.
+
+        Returns:
+            Dict containing:
+                - 'temp' (Temperature): Current outdoor temperature
+                - 'feelsLike' (Temperature): Feels-like temperature
+                - 'min' (Temperature): Today's minimum temperature
+                - 'max' (Temperature): Today's maximum temperature
+                - 'pressure' (int): Atmospheric pressure in hPa
+                - 'humidity' (int): Relative humidity in %
+                - 'wind' (float): Wind speed
+                - 'windDir' (int): Wind direction in degrees
+                - 'clouds' (int): Cloud cover in %
+                - 'snow' (float): Snow amount
+                - 'rain' (float): Rain amount
+                - 'description' (str): Weather description (e.g., "mist")
+                - 'icon' (str): Weather icon code
+
+        Raises:
+            RuntimeError: If building info or weather data is not found.
+        """
+        if building_info is None:
+            try:
+                building_info = await self.sensorlinx.get_buildings(self.building_id)
+            except Exception as e:
+                raise RuntimeError(f"Failed to fetch building info: {e}")
+        if not building_info:
+            raise RuntimeError("Building info not found.")
+
+        if isinstance(building_info, list):
+            building_info = building_info[0]
+
+        weather_data = building_info.get('weather', {}).get('weather')
+        if not weather_data:
+            raise RuntimeError("Current weather data not found.")
+
+        return {
+            'temp': Temperature(weather_data['temp'], 'F'),
+            'feelsLike': Temperature(weather_data['feelsLike'], 'F'),
+            'min': Temperature(weather_data['min'], 'F'),
+            'max': Temperature(weather_data['max'], 'F'),
+            'pressure': weather_data.get('pressure'),
+            'humidity': weather_data.get('humidity'),
+            'wind': weather_data.get('wind'),
+            'windDir': weather_data.get('windDir'),
+            'clouds': weather_data.get('clouds'),
+            'snow': weather_data.get('snow', 0),
+            'rain': weather_data.get('rain', 0),
+            'description': weather_data.get('description'),
+            'icon': weather_data.get('icon'),
+            'weatherId': weather_data.get('weatherId'),
+        }
+
+    async def get_forecast(self, building_info: Optional[Dict] = None) -> List[Dict]:
+        """
+        Retrieve the weather forecast for the building.
+
+        Weather data is attached to the building, not the device.
+
+        Args:
+            building_info (Optional[Dict]): If provided, use this building dict instead of fetching from API.
+
+        Returns:
+            List of forecast period dicts, each containing:
+                - 'time' (datetime): Forecast period start time (UTC)
+                - 'pop' (int): Probability of precipitation in %
+                - 'snow' (float): Snow amount
+                - 'temp' (Temperature): Forecast temperature
+                - 'min' (Temperature): Minimum temperature for the period
+                - 'max' (Temperature): Maximum temperature for the period
+                - 'description' (str): Weather description
+                - 'icon' (str): Weather icon code
+
+        Raises:
+            RuntimeError: If building info or forecast data is not found.
+        """
+        if building_info is None:
+            try:
+                building_info = await self.sensorlinx.get_buildings(self.building_id)
+            except Exception as e:
+                raise RuntimeError(f"Failed to fetch building info: {e}")
+        if not building_info:
+            raise RuntimeError("Building info not found.")
+
+        if isinstance(building_info, list):
+            building_info = building_info[0]
+
+        forecast_data = building_info.get('weather', {}).get('forecast')
+        if forecast_data is None:
+            raise RuntimeError("Forecast data not found.")
+        if not isinstance(forecast_data, list):
+            raise RuntimeError("Forecast data must be a list.")
+
+        result = []
+        for period in forecast_data:
+            result.append({
+                'time': datetime.datetime.fromisoformat(period['time'].replace('Z', '+00:00')),
+                'pop': period.get('pop', 0),
+                'snow': period.get('snow', 0),
+                'temp': Temperature(period['temp'], 'F'),
+                'min': Temperature(period['min'], 'F'),
+                'max': Temperature(period['max'], 'F'),
+                'description': period.get('description'),
+                'icon': period.get('icon'),
+                'weatherId': period.get('weatherId'),
+            })
+        return result

--- a/tests/get_parameter_test.py
+++ b/tests/get_parameter_test.py
@@ -728,4 +728,142 @@ async def test_get_runtimes_cases(device_info, get_devices_side_effect, expected
         if "backup" in expected_result:
             assert result["backup"] == expected_result["backup"]
         else:
-            assert "backup" not in result                    
+            assert "backup" not in result
+
+SAMPLE_BUILDING_INFO = {
+    "weather": {
+        "weather": {
+            "temp": 45.52,
+            "feelsLike": 42.48,
+            "min": 43.34,
+            "max": 47.86,
+            "pressure": 1024,
+            "humidity": 89,
+            "wind": 5.75,
+            "windDir": 210,
+            "clouds": 100,
+            "snow": 0,
+            "rain": 0,
+            "type": "Mist",
+            "description": "mist",
+            "icon": "50d",
+            "weatherId": 701,
+        },
+        "forecast": [
+            {
+                "time": "2026-04-03T18:00:00.000Z",
+                "pop": 0,
+                "snow": 0,
+                "temp": 49.6,
+                "min": 49.6,
+                "max": 63.91,
+                "description": "overcast clouds",
+                "icon": "04d",
+                "weatherId": 804,
+            },
+            {
+                "time": "2026-04-04T00:00:00.000Z",
+                "pop": 0,
+                "snow": 0,
+                "temp": 58.17,
+                "min": 44.83,
+                "max": 60.78,
+                "description": "overcast clouds",
+                "icon": "04n",
+                "weatherId": 804,
+            },
+        ],
+    }
+}
+
+@pytest.mark.get_params
+async def test_get_current_weather_smoke():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    result = await device.get_current_weather(SAMPLE_BUILDING_INFO)
+    assert isinstance(result["temp"], Temperature)
+    assert result["temp"].to_fahrenheit() == 45.52
+    assert isinstance(result["feelsLike"], Temperature)
+    assert result["feelsLike"].to_fahrenheit() == 42.48
+    assert result["humidity"] == 89
+    assert result["pressure"] == 1024
+    assert result["description"] == "mist"
+    assert result["icon"] == "50d"
+    assert result["weatherId"] == 701
+
+@pytest.mark.get_params
+async def test_get_current_weather_fetches_building():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    sensorlinx.get_buildings = AsyncMock(return_value=SAMPLE_BUILDING_INFO)
+    result = await device.get_current_weather()
+    sensorlinx.get_buildings.assert_awaited_once_with("building123")
+    assert result["temp"].to_fahrenheit() == 45.52
+
+@pytest.mark.get_params
+async def test_get_current_weather_accepts_list():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    result = await device.get_current_weather([SAMPLE_BUILDING_INFO])
+    assert result["temp"].to_fahrenheit() == 45.52
+
+@pytest.mark.get_params
+async def test_get_current_weather_missing_data():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    with pytest.raises(RuntimeError, match="Current weather data not found."):
+        await device.get_current_weather({"weather": {}})
+
+@pytest.mark.get_params
+async def test_get_current_weather_fetch_failure():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    sensorlinx.get_buildings = AsyncMock(side_effect=Exception("network error"))
+    with pytest.raises(RuntimeError, match="Failed to fetch building info: network error"):
+        await device.get_current_weather()
+
+@pytest.mark.get_params
+async def test_get_forecast_smoke():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    result = await device.get_forecast(SAMPLE_BUILDING_INFO)
+    assert len(result) == 2
+    assert isinstance(result[0]["time"], datetime.datetime)
+    assert result[0]["time"].tzinfo is not None
+    assert isinstance(result[0]["temp"], Temperature)
+    assert result[0]["temp"].to_fahrenheit() == 49.6
+    assert result[0]["pop"] == 0
+    assert result[0]["description"] == "overcast clouds"
+    assert result[0]["weatherId"] == 804
+    assert result[1]["temp"].to_fahrenheit() == 58.17
+
+@pytest.mark.get_params
+async def test_get_forecast_fetches_building():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    sensorlinx.get_buildings = AsyncMock(return_value=SAMPLE_BUILDING_INFO)
+    result = await device.get_forecast()
+    sensorlinx.get_buildings.assert_awaited_once_with("building123")
+    assert len(result) == 2
+
+@pytest.mark.get_params
+async def test_get_forecast_missing_data():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    with pytest.raises(RuntimeError, match="Forecast data not found."):
+        await device.get_forecast({"weather": {}})
+
+@pytest.mark.get_params
+async def test_get_forecast_not_a_list():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    with pytest.raises(RuntimeError, match="Forecast data must be a list."):
+        await device.get_forecast({"weather": {"forecast": "bad"}})
+
+@pytest.mark.get_params
+async def test_get_forecast_fetch_failure():
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    sensorlinx.get_buildings = AsyncMock(side_effect=Exception("timeout"))
+    with pytest.raises(RuntimeError, match="Failed to fetch building info: timeout"):
+        await device.get_forecast()


### PR DESCRIPTION
Add get_current_weather() and get_forecast() to SensorlinxDevice. 

Weather data is building-level (from get_buildings), not device-level. Both methods accept an optional building_info dict to avoid redundant API calls.

[Note that this was developed with the assistance of Claude Code.  Reviews were done manually]