### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysensorlinx"          
-version = "0.2.0"             
+version = "0.2.1"             
 description = "Python library for accessing SensorLinx Device Data"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pysensorlinx/__init__.py
+++ b/src/pysensorlinx/__init__.py
@@ -1,4 +1,4 @@
 from .sensorlinx import Sensorlinx, Temperature, TemperatureDelta, SensorlinxDevice, InvalidCredentialsError, LoginTimeoutError, LoginError, InvalidParameterError
 
 __all__ = ["Sensorlinx", "Temperature", "TemperatureDelta", "SensorlinxDevice", "InvalidCredentialsError", "LoginTimeoutError", "LoginError", "InvalidParameterError"]
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/live_test.py
+++ b/tests/live_test.py
@@ -735,3 +735,25 @@ async def test_live_get_backup_state():
         pytest.fail(f"Test failed due to exception: {type(e).__name__}: {e}")
     finally:
         await sensorlinx.close()
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.getenv("SENSORLINX_EMAIL") or not os.getenv("SENSORLINX_PASSWORD") or not os.getenv("SENSORLINX_BUILDING_ID"),
+    reason="SENSORLINX_EMAIL or SENSORLINX_PASSWORD or SENSORLINX_BUILDING_ID environment variable not set"
+)
+@pytest.mark.asyncio
+async def test_live_get_device_with_invalid_id_includes_error_body():
+    """Passing an invalid device_id should raise RuntimeError whose message
+    includes the API response body (not just the status code)."""
+    sensorlinx = Sensorlinx()
+    username = os.getenv("SENSORLINX_EMAIL")
+    password = os.getenv("SENSORLINX_PASSWORD")
+    building_id = os.getenv("SENSORLINX_BUILDING_ID")
+
+    try:
+        await sensorlinx.login(username, password)
+        with pytest.raises(RuntimeError, match="status 400"):
+            await sensorlinx.get_devices(building_id, "INVALID-ID")
+    finally:
+        await sensorlinx.close()


### PR DESCRIPTION
Bumps version to 0.2.1 for PyPI release.

### Changes in 0.2.1 (since 0.2.0)
- **fix:** Quick Start README used \_id\ instead of \syncCode\ for device_id, causing HTTP 400 errors (fixes #10, #13)
- **fix:** API error messages now include the server's response body for easier debugging (#13)
- **fix:** Quick Start example wrapped in \	ry/finally\ to prevent unclosed session warnings

### Files changed
- \pyproject.toml\ — version 0.2.0 → 0.2.1
- \src/pysensorlinx/__init__.py\ — version 0.2.0 → 0.2.1

All 708 unit tests passing.