### PR TITLE
feat: add get_demands(), get_system_state(), and system state example

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -160,7 +160,8 @@ The HBX ECO-0600 is a heat pump staging controller for hydronic (water-based) he
 - **Weather:** Current conditions and forecast are stored at the building level (not device level). Accessed via `get_buildings(building_id)` — the building dict has a `weather.weather` key (current conditions) and `weather.forecast` key (list of periods). Both `get_current_weather()` and `get_forecast()` on `SensorlinxDevice` accept an optional `building_info` dict to avoid redundant API calls. Temperatures in weather data are in °F and are returned as `Temperature` objects.
 - **Demands:** Heat demand (`hd`), cool demand (`cd`), and domestic hot water (`dhw`) are independent demand channels. Runtime state for all three is in the `demands` list in the device info.
 - **DHW:** Controlled via `dhwOn` (enabled bool), `dhwT` (target temp °F), and `auxDif` (differential TemperatureDelta). The DHW tank sensor appears as `temp4` / `"type": "dhw"` in the temperatures array.
-- **Temperature sensors:** Up to 4 sensor inputs (tank, outdoor, and two auxiliary). Accessed via `tB1`–`tB4` (raw) or the `temperatures` array (structured).
+- **Pumps:** Two configurable pump outputs (`pmp1Set`, `pmp2Set`). Each is assigned a mode: `0`=System, `1`=Heating, `2`=Cooling, `3`=DHW, `4`=App, `5`=None. Pumps are associated with demand calls, not tanks. Runtime state is in the `pumps` array; mode config is in `pmp1Set`/`pmp2Set`.
+- **Temperature sensors:** Up to 4 sensor inputs (tank, outdoor, and two auxiliary). Accessed via `tB1`–`tB4` (raw) or the `temperatures` array (structured). The enhanced `temperatures` array includes `activatedState` (e.g., `"satisfied"`) and `type` (e.g., `"single"`, `"outdoor"`, `"dhw"`).
 
 ## Development Environment
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A high-level wrapper around a single device. All methods are `async`.
 | `get_dhw_target_temp()` | `Temperature` | |
 | `get_dhw_differential()` | `TemperatureDelta` | |
 | `get_dhw_state()` | `dict` | DHW demand state with `activated`, `enabled`, `title` |
+| `get_demands()` | `list[dict]` | All demand channels (hd, cd, dhw) with `activated`, `enabled`, `name`, `title` |
 | `get_backup_lag_time()` | `int \| 'off'` | minutes |
 | `get_backup_temp()` | `Temperature \| 'off'` | |
 | `get_backup_differential()` | `TemperatureDelta \| 'off'` | |
@@ -177,6 +178,7 @@ A high-level wrapper around a single device. All methods are `async`.
 | `get_backup_state()` | `dict` | Backup state with `activated`, `enabled`, `title`, `runTime` |
 | `get_current_weather()` | `dict` | Current conditions: `temp`, `feelsLike`, `min`, `max` as `Temperature`; `pressure`, `humidity`, `wind`, `windDir`, `clouds`, `snow`, `rain`, `description`, `icon`, `weatherId` |
 | `get_forecast()` | `list[dict]` | Forecast periods: `time` as `datetime`, `temp`/`min`/`max` as `Temperature`, `pop`, `snow`, `description`, `icon`, `weatherId` |
+| `get_system_state()` | `dict` | Bundled runtime state: `demands`, `temperatures`, `stages`, `backup`, `pumps`, `reversingValve`, `weatherShutdown` |
 
 #### Weather conditions
 

--- a/examples/system_state.py
+++ b/examples/system_state.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Display the complete ECO-0600 system state in a hierarchical view."""
+
+import asyncio
+import os
+import sys
+
+from pysensorlinx import Sensorlinx, SensorlinxDevice
+
+
+def temp_str(t):
+    """Format a Temperature object as a short string."""
+    if t is None:
+        return "—"
+    return f"{t.to_fahrenheit():.1f}°F"
+
+
+def status_icon(active):
+    """Return a status indicator."""
+    return "ON" if active else "off"
+
+
+def print_system_state(state):
+    # ── Weather Shutdown ──
+    ws = state.get("weatherShutdown")
+    shutdowns_active = []
+    if ws:
+        for key in ("wwsd", "cwsd"):
+            entry = ws.get(key, {})
+            if entry.get("activated"):
+                shutdowns_active.append(entry.get("title", key.upper()))
+
+    if shutdowns_active:
+        print(f"  *** WEATHER SHUTDOWN ACTIVE: {', '.join(shutdowns_active)} ***")
+        print()
+
+    # ── Build a map of temperature sensors by type ──
+    temp_by_type = {}
+    temps = state.get("temperatures") or []
+    for t in temps:
+        t_type = t.get("type")
+        if t_type:
+            temp_by_type[t_type] = t
+
+    # ── Build a map of pumps by mode ──
+    pumps_by_mode = {}
+    for p in state.get("pumps") or []:
+        mode = p.get("mode")
+        if mode:
+            pumps_by_mode.setdefault(mode, []).append(p)
+
+    # ── Demands ──
+    demands = state.get("demands") or []
+    stages = state.get("stages") or []
+    backup = state.get("backup")
+    rv = state.get("reversingValve")
+
+    # Map demand names to temperature types
+    demand_temp_map = {
+        "hd": "single",   # heat demand → hot tank (or single tank)
+        "cd": "single",   # cool demand → cold tank (or single tank)
+        "dhw": "dhw",      # DHW demand → DHW tank
+    }
+
+    # Map demand names to relevant pump modes
+    demand_pump_map = {
+        "hd": ["heating", "system"],
+        "cd": ["cooling", "system"],
+        "dhw": ["dhw"],
+    }
+
+    for demand in demands:
+        if not demand.get("enabled"):
+            continue
+
+        name = demand.get("name", "?")
+        title = demand.get("title", name)
+        active = demand.get("activated", False)
+
+        marker = ">>>" if active else "   "
+        label = f"[{status_icon(active)}]"
+        print(f"  {marker} {title} Demand {label}")
+
+        # Show associated temperature sensor
+        t_type = demand_temp_map.get(name)
+        temp = temp_by_type.get(t_type)
+        if temp:
+            current = temp_str(temp.get("current"))
+            target = temp_str(temp.get("target"))
+            a_state = temp.get("activatedState")
+
+            # Check if this demand is affected by weather shutdown
+            shutdown_label = None
+            if ws and name == "hd" and ws.get("wwsd", {}).get("activated"):
+                shutdown_label = "WWSD"
+            elif ws and name == "cd" and ws.get("cwsd", {}).get("activated"):
+                shutdown_label = "CWSD"
+
+            tank_line = f"        Tank: {current}"
+            if temp.get("target") is not None:
+                tank_line += f" / target {target}"
+            if a_state and active:
+                tank_line += f"  ({a_state})"
+            if shutdown_label:
+                tank_line += f"  [{shutdown_label}]"
+            print(tank_line)
+
+        # Show stages and backup only under the active demand that drives them
+        # (stages respond to hd/cd, not dhw)
+        if active and name in ("hd", "cd"):
+            if stages:
+                running = [s for s in stages if s.get("activated")]
+                enabled = [s for s in stages if s.get("enabled")]
+                if running:
+                    for s in running:
+                        print(f"        Stage: {s['title']} [ON]  runtime {s.get('runTime', '?')}")
+                else:
+                    print(f"        Stages: {len(enabled)} enabled, none running")
+
+            if backup:
+                bk_status = status_icon(backup.get("activated"))
+                if backup.get("enabled") or backup.get("activated"):
+                    print(f"        Backup: [{bk_status}]  runtime {backup.get('runTime', '?')}")
+
+            # Reversing valve (relevant for heat/cool switching)
+            if rv:
+                print(f"        Reversing Valve: [{status_icon(rv.get('activated'))}]")
+
+        # Show associated pumps
+        pump_modes = demand_pump_map.get(name, [])
+        for mode in pump_modes:
+            for p in pumps_by_mode.get(mode, []):
+                p_status = status_icon(p.get("activated"))
+                print(f"        {p.get('title', 'Pump')}: [{p_status}]  mode={mode}")
+
+        print()
+
+    # ── Outdoor temperature ──
+    outdoor = temp_by_type.get("outdoor")
+    if outdoor:
+        print(f"  Outdoor: {temp_str(outdoor.get('current'))}")
+
+    # ── Weather shutdown status ──
+    if ws and not shutdowns_active:
+        print(f"  Weather Shutdown: none active")
+
+
+async def main():
+    email = os.getenv("SENSORLINX_EMAIL")
+    password = os.getenv("SENSORLINX_PASSWORD")
+    building_id = os.getenv("SENSORLINX_BUILDING_ID")
+    device_id = os.getenv("SENSORLINX_DEVICE_ID")
+
+    if not email or not password:
+        print("Set SENSORLINX_EMAIL and SENSORLINX_PASSWORD environment variables.", file=sys.stderr)
+        sys.exit(1)
+
+    api = Sensorlinx()
+    try:
+        await api.login(email, password)
+
+        # Auto-discover building and device if not specified
+        if not building_id:
+            buildings = await api.get_buildings()
+            building_id = buildings[0]["id"]
+        if not device_id:
+            devices = await api.get_devices(building_id)
+            device_id = devices[0]["syncCode"]
+
+        device = SensorlinxDevice(api, building_id, device_id)
+        state = await device.get_system_state()
+
+        print()
+        print(f"  ECO-0600 System State  ({device_id})")
+        print(f"  {'=' * 40}")
+        print()
+        print_system_state(state)
+        print()
+    finally:
+        await api.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -82,6 +82,21 @@ DHW_ENABLED = "dhwOn"
 DHW_TARGET_TEMP = "dhwT"
 DHW_DIFFERENTIAL = "auxDif"
 DEMANDS = "demands"
+PUMPS = "pumps"
+PUMP_1_MODE = "pmp1Set"
+PUMP_2_MODE = "pmp2Set"
+REVERSING_VALVE = "reversingValve"
+WEATHER_SHUTDOWN_STATUS = "wsd"
+TEMPERATURES_ENHANCED = "temperatures"
+
+PUMP_MODES = {
+    0: "system",
+    1: "heating",
+    2: "cooling",
+    3: "dhw",
+    4: "app",
+    5: "none",
+}
 
 CONF_SITE_NAME = "site_name"       # The name of the site (e.g., "home")
 CONF_SENSOR_IDS = "sensor_ids"     # List of sensor IDs to extract (empty = all)
@@ -1972,21 +1987,22 @@ class SensorlinxDevice:
         value = await self._get_device_info_value(DHW_DIFFERENTIAL, device_info)
         return TemperatureDelta(value, 'F')
 
-    async def get_dhw_state(self, device_info: Optional[Dict] = None) -> Dict[str, Union[bool, str]]:
+    async def get_demands(self, device_info: Optional[Dict] = None) -> List[Dict[str, Union[bool, str]]]:
         """
-        Retrieve the runtime state of the Domestic Hot Water (DHW) demand channel.
+        Retrieve the state of all demand channels (heat, cool, DHW).
 
         Args:
             device_info (Optional[Dict]): If provided, use this device_info dict instead of fetching from API.
 
         Returns:
-            Dict[str, Union[bool, str]]: A dictionary containing:
-                - 'activated' (bool): Whether DHW demand is currently active
-                - 'enabled' (bool): Whether the DHW channel is enabled
-                - 'title' (str): The display title (e.g., "DHW")
+            List[Dict[str, Union[bool, str]]]: A list of dictionaries, each containing:
+                - 'activated' (bool): Whether this demand is currently active
+                - 'enabled' (bool): Whether this demand channel is enabled
+                - 'name' (str): The demand channel identifier ('hd', 'cd', 'dhw')
+                - 'title' (str): The display title (e.g., "Heat", "Cool", "DHW")
 
         Raises:
-            RuntimeError: If device info or DHW demand data is not found.
+            RuntimeError: If device info or demands data is not found.
         """
         if device_info is None:
             try:
@@ -2004,14 +2020,168 @@ class SensorlinxDevice:
         if not isinstance(demands, list):
             raise RuntimeError("Demands data must be a list.")
 
-        dhw = next((d for d in demands if d.get('name') == 'dhw'), None)
+        return [
+            {
+                'activated': d.get('activated', False),
+                'enabled': d.get('enabled', False),
+                'name': d.get('name', ''),
+                'title': d.get('title', ''),
+            }
+            for d in demands
+        ]
+
+    async def get_dhw_state(self, device_info: Optional[Dict] = None) -> Dict[str, Union[bool, str]]:
+        """
+        Retrieve the runtime state of the Domestic Hot Water (DHW) demand channel.
+
+        Args:
+            device_info (Optional[Dict]): If provided, use this device_info dict instead of fetching from API.
+
+        Returns:
+            Dict[str, Union[bool, str]]: A dictionary containing:
+                - 'activated' (bool): Whether DHW demand is currently active
+                - 'enabled' (bool): Whether the DHW channel is enabled
+                - 'title' (str): The display title (e.g., "DHW")
+
+        Raises:
+            RuntimeError: If device info or DHW demand data is not found.
+        """
+        all_demands = await self.get_demands(device_info)
+        dhw = next((d for d in all_demands if d.get('name') == 'dhw'), None)
         if dhw is None:
             raise RuntimeError("DHW demand not found.")
 
         return {
-            'activated': dhw.get('activated', False),
-            'enabled': dhw.get('enabled', False),
-            'title': dhw.get('title', 'DHW'),
+            'activated': dhw['activated'],
+            'enabled': dhw['enabled'],
+            'title': dhw['title'],
+        }
+
+    async def get_system_state(self, device_info: Optional[Dict] = None) -> Dict:
+        """
+        Retrieve the complete runtime state of the system in a single API call.
+
+        Bundles demands, temperatures, heat pump stages, backup, pumps,
+        reversing valve, and weather shutdown status into one response.
+
+        Args:
+            device_info (Optional[Dict]): If provided, use this device_info dict instead of fetching from API.
+
+        Returns:
+            Dict containing:
+                - 'demands' (list): Demand channels with 'activated', 'enabled', 'name', 'title'
+                - 'temperatures' (list): Enabled sensors with 'title', 'type', 'current', 'target',
+                  'activated', 'activatedState', 'enabled'
+                - 'stages' (list): Heat pump stages with 'activated', 'enabled', 'title', 'device',
+                  'index', 'runTime'
+                - 'backup' (dict): Backup state with 'activated', 'enabled', 'title', 'runTime'
+                - 'pumps' (list): Pump states with 'activated', 'title', 'mode'
+                - 'reversingValve' (dict): Reversing valve with 'activated', 'title'
+                - 'weatherShutdown' (dict): WWSD/CWSD status dicts with 'activated', 'title'
+
+            Any section that cannot be parsed returns None instead of raising.
+
+        Raises:
+            RuntimeError: If device info cannot be fetched.
+        """
+        if device_info is None:
+            try:
+                device_info = await self.sensorlinx.get_devices(self.building_id, self.device_id)
+            except Exception as e:
+                raise RuntimeError(f"Failed to fetch device info: {e}")
+        if not device_info:
+            raise RuntimeError("Device info not found.")
+
+        # Demands — delegate to existing method
+        try:
+            demands = await self.get_demands(device_info)
+        except Exception:
+            demands = None
+
+        # Temperatures — use the enhanced 'temperatures' array
+        try:
+            temps_data = await self._get_device_info_value(TEMPERATURES_ENHANCED, device_info)
+            temperatures = []
+            for t in temps_data:
+                if not t.get('enabled', False):
+                    continue
+                current = t.get('current')
+                target = t.get('target')
+                temperatures.append({
+                    'title': t.get('title'),
+                    'type': t.get('type'),
+                    'current': Temperature(current, 'F') if current is not None else None,
+                    'target': Temperature(target, 'F') if target is not None else None,
+                    'activated': t.get('activated', False),
+                    'activatedState': t.get('activatedState'),
+                    'enabled': True,
+                })
+        except Exception:
+            temperatures = None
+
+        # Stages — delegate to existing method
+        try:
+            stages = await self.get_heatpump_stages_state(device_info)
+        except Exception:
+            stages = None
+
+        # Backup — delegate to existing method
+        try:
+            backup = await self.get_backup_state(device_info)
+        except Exception:
+            backup = None
+
+        # Pumps — merge state array with mode config
+        try:
+            pumps_data = await self._get_device_info_value(PUMPS, device_info)
+            pump_mode_keys = [PUMP_1_MODE, PUMP_2_MODE]
+            pumps = []
+            for i, p in enumerate(pumps_data):
+                mode_value = None
+                if i < len(pump_mode_keys):
+                    try:
+                        mode_value = await self._get_device_info_value(pump_mode_keys[i], device_info)
+                    except Exception:
+                        pass
+                pumps.append({
+                    'activated': p.get('activated', False),
+                    'title': p.get('title', ''),
+                    'mode': PUMP_MODES.get(mode_value, f"unknown ({mode_value})") if mode_value is not None else None,
+                })
+        except Exception:
+            pumps = None
+
+        # Reversing Valve
+        try:
+            rv_data = await self._get_device_info_value(REVERSING_VALVE, device_info)
+            reversing_valve = {
+                'activated': rv_data.get('activated', False),
+                'title': rv_data.get('title', 'Reversing Valve'),
+            }
+        except Exception:
+            reversing_valve = None
+
+        # Weather Shutdown Status
+        try:
+            wsd_data = await self._get_device_info_value(WEATHER_SHUTDOWN_STATUS, device_info)
+            weather_shutdown = {}
+            for key in ('wwsd', 'cwsd'):
+                entry = wsd_data.get(key, {})
+                weather_shutdown[key] = {
+                    'activated': entry.get('activated', False),
+                    'title': entry.get('title', key.upper()),
+                }
+        except Exception:
+            weather_shutdown = None
+
+        return {
+            'demands': demands,
+            'temperatures': temperatures,
+            'stages': stages,
+            'backup': backup,
+            'pumps': pumps,
+            'reversingValve': reversing_valve,
+            'weatherShutdown': weather_shutdown,
         }
 
     async def get_backup_lag_time(self, device_info: Optional[Dict] = None) -> Union[int, str]:

--- a/tests/get_parameter_test.py
+++ b/tests/get_parameter_test.py
@@ -775,6 +775,96 @@ async def test_get_dhw_target_temp_smoke():
 @pytest.mark.parametrize(
     "device_info, get_devices_side_effect, expected_result, expected_exception, expected_message",
     [
+        # Success: all three demands present
+        (
+            {"demands": [
+                {"name": "hd", "title": "Heat", "enabled": True, "activated": True},
+                {"name": "cd", "title": "Cool", "enabled": True, "activated": False},
+                {"name": "dhw", "title": "DHW", "enabled": True, "activated": False},
+            ]},
+            None,
+            [
+                {"activated": True, "enabled": True, "name": "hd", "title": "Heat"},
+                {"activated": False, "enabled": True, "name": "cd", "title": "Cool"},
+                {"activated": False, "enabled": True, "name": "dhw", "title": "DHW"},
+            ],
+            None,
+            None,
+        ),
+        # Success: single demand
+        (
+            {"demands": [
+                {"name": "hd", "title": "Heat", "enabled": True, "activated": False},
+            ]},
+            None,
+            [
+                {"activated": False, "enabled": True, "name": "hd", "title": "Heat"},
+            ],
+            None,
+            None,
+        ),
+        # Success: missing optional fields get defaults
+        (
+            {"demands": [
+                {"name": "hd"},
+            ]},
+            None,
+            [
+                {"activated": False, "enabled": False, "name": "hd", "title": ""},
+            ],
+            None,
+            None,
+        ),
+        # Failure: demands not a list
+        (
+            {"demands": {"name": "hd"}},
+            None,
+            None,
+            RuntimeError,
+            "Demands data must be a list.",
+        ),
+        # Failure: device_info is None, get_devices returns None
+        (
+            None,
+            None,
+            None,
+            RuntimeError,
+            "Device info not found.",
+        ),
+        # Failure: get_devices raises exception
+        (
+            None,
+            Exception("network error"),
+            None,
+            RuntimeError,
+            "Failed to fetch device info: network error",
+        ),
+    ]
+)
+async def test_get_demands_cases(device_info, get_devices_side_effect, expected_result, expected_exception, expected_message):
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    if device_info is None:
+        if isinstance(get_devices_side_effect, Exception):
+            sensorlinx.get_devices = AsyncMock(side_effect=get_devices_side_effect)
+        else:
+            sensorlinx.get_devices = AsyncMock(return_value=get_devices_side_effect)
+        call_device_info = None
+    else:
+        call_device_info = device_info
+
+    if expected_exception:
+        with pytest.raises(expected_exception, match=expected_message):
+            await device.get_demands(device_info=call_device_info)
+    else:
+        result = await device.get_demands(device_info=call_device_info)
+        assert result == expected_result
+
+@pytest.mark.get_params
+@pytest.mark.parametrize(
+    "device_info, get_devices_side_effect, expected_result, expected_exception, expected_message",
+    [
         # Success: DHW present and enabled
         (
             {"demands": [
@@ -852,6 +942,177 @@ async def test_get_dhw_state_cases(device_info, get_devices_side_effect, expecte
     else:
         result = await device.get_dhw_state(device_info=call_device_info)
         assert result == expected_result
+
+FULL_DEVICE_INFO = {
+    "demands": [
+        {"name": "hd", "title": "Heat", "enabled": True, "activated": True},
+        {"name": "cd", "title": "Cool", "enabled": True, "activated": False},
+        {"name": "dhw", "title": "DHW", "enabled": True, "activated": False},
+    ],
+    "temperatures": [
+        {
+            "activated": True, "activatedColor": "green", "activatedState": "satisfied",
+            "current": 107.7, "enabled": True, "target": 103.2,
+            "title": "Tank", "type": "single",
+            "priority": {"enabled": True, "title": "Heating", "type": "hot"},
+        },
+        {
+            "activated": False, "activatedColor": None, "activatedState": None,
+            "current": None, "enabled": False, "target": None,
+            "title": None, "type": None,
+            "priority": {"enabled": False, "title": "Heating", "type": "hot"},
+        },
+        {
+            "activated": False, "activatedColor": None, "activatedState": None,
+            "current": 49.6, "enabled": True, "target": None,
+            "title": "Outdoor", "type": "outdoor",
+            "priority": {"enabled": False, "title": "Heating", "type": "hot"},
+        },
+        {
+            "activated": False, "activatedColor": None, "activatedState": None,
+            "current": 121.6, "enabled": True, "target": 119,
+            "title": "DHW Tank", "type": "dhw",
+            "priority": {"enabled": False, "title": "Heating", "type": "hot"},
+        },
+    ],
+    "stages": [
+        {"activated": False, "device": "AECO-0982", "enabled": True,
+         "index": 1, "runTime": "3455:32", "title": "Stage 1"},
+    ],
+    "backup": {"activated": False, "enabled": False, "runTime": "65535:00", "title": "Backup"},
+    "pumps": [
+        {"activated": False, "title": "Pump 1"},
+        {"activated": False, "title": "Pump 2"},
+    ],
+    "pmp1Set": 1,
+    "pmp2Set": 3,
+    "reversingValve": {"activated": False, "title": "Reversing Valve"},
+    "wsd": {
+        "wwsd": {"activated": False, "title": "WWSD"},
+        "cwsd": {"activated": False, "title": "CWSD"},
+    },
+}
+
+@pytest.mark.get_params
+async def test_get_system_state_full():
+    """All sections present and populated."""
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    result = await device.get_system_state(device_info=FULL_DEVICE_INFO)
+
+    # Demands
+    assert len(result['demands']) == 3
+    assert result['demands'][0] == {'activated': True, 'enabled': True, 'name': 'hd', 'title': 'Heat'}
+
+    # Temperatures — disabled sensor filtered out
+    assert len(result['temperatures']) == 3
+    tank = result['temperatures'][0]
+    assert tank['title'] == 'Tank'
+    assert tank['type'] == 'single'
+    assert tank['activatedState'] == 'satisfied'
+    assert isinstance(tank['current'], Temperature)
+    assert tank['current'].to_fahrenheit() == 107.7
+    assert isinstance(tank['target'], Temperature)
+    assert tank['target'].to_fahrenheit() == 103.2
+
+    outdoor = result['temperatures'][1]
+    assert outdoor['title'] == 'Outdoor'
+    assert outdoor['target'] is None
+
+    dhw_tank = result['temperatures'][2]
+    assert dhw_tank['type'] == 'dhw'
+    assert isinstance(dhw_tank['current'], Temperature)
+
+    # Stages
+    assert len(result['stages']) == 1
+    assert result['stages'][0]['activated'] is False
+    assert result['stages'][0]['title'] == 'Stage 1'
+
+    # Backup
+    assert result['backup']['activated'] is False
+    assert result['backup']['enabled'] is False
+
+    # Pumps — mode resolved from pmp1Set/pmp2Set
+    assert len(result['pumps']) == 2
+    assert result['pumps'][0] == {'activated': False, 'title': 'Pump 1', 'mode': 'heating'}
+    assert result['pumps'][1] == {'activated': False, 'title': 'Pump 2', 'mode': 'dhw'}
+
+    # Reversing valve
+    assert result['reversingValve'] == {'activated': False, 'title': 'Reversing Valve'}
+
+    # Weather shutdown
+    assert result['weatherShutdown']['wwsd'] == {'activated': False, 'title': 'WWSD'}
+    assert result['weatherShutdown']['cwsd'] == {'activated': False, 'title': 'CWSD'}
+
+
+@pytest.mark.get_params
+async def test_get_system_state_missing_optional_sections():
+    """Sections missing from device_info return None instead of raising."""
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    minimal_info = {
+        "demands": [
+            {"name": "hd", "title": "Heat", "enabled": True, "activated": False},
+        ],
+        "stages": [
+            {"activated": False, "enabled": True, "index": 1, "title": "Stage 1",
+             "device": "X", "runTime": "0:00"},
+        ],
+        "backup": {"activated": False, "enabled": False, "title": "Backup", "runTime": "0:00"},
+    }
+    result = await device.get_system_state(device_info=minimal_info)
+
+    assert result['demands'] is not None
+    assert result['stages'] is not None
+    assert result['backup'] is not None
+    assert result['temperatures'] is None
+    assert result['pumps'] is None
+    assert result['reversingValve'] is None
+    assert result['weatherShutdown'] is None
+
+
+@pytest.mark.get_params
+async def test_get_system_state_device_info_none_fetch_failure():
+    """Raises RuntimeError when device_info is None and fetch fails."""
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+    sensorlinx.get_devices = AsyncMock(side_effect=Exception("network error"))
+
+    with pytest.raises(RuntimeError, match="Failed to fetch device info: network error"):
+        await device.get_system_state()
+
+
+@pytest.mark.get_params
+async def test_get_system_state_device_info_empty():
+    """Raises RuntimeError when device_info is empty."""
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    with pytest.raises(RuntimeError, match="Device info not found."):
+        await device.get_system_state(device_info={})
+
+
+@pytest.mark.get_params
+async def test_get_system_state_pump_unknown_mode():
+    """Unknown pump mode value renders as 'unknown (N)'."""
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    info = {
+        "demands": [],
+        "temperatures": [],
+        "stages": [],
+        "backup": {"activated": False, "enabled": False, "title": "Backup", "runTime": "0:00"},
+        "pumps": [{"activated": True, "title": "Pump 1"}],
+        "pmp1Set": 99,
+        "reversingValve": {"activated": False, "title": "RV"},
+        "wsd": {"wwsd": {"activated": False, "title": "WWSD"}, "cwsd": {"activated": False, "title": "CWSD"}},
+    }
+    result = await device.get_system_state(device_info=info)
+    assert result['pumps'][0]['mode'] == 'unknown (99)'
+
 
 SAMPLE_BUILDING_INFO= {
     "weather": {


### PR DESCRIPTION
## Summary
- Add `get_demands()` to retrieve all demand channels (hd, cd, dhw) with activated/enabled state
- Add `get_system_state()` to bundle the complete runtime state in a single API call — demands, enhanced temperatures (with `activatedState`), stages, backup, pumps (with mode mapping), reversing valve, and weather shutdown status
- Refactor `get_dhw_state()` to delegate to `get_demands()` internally
- Add pump mode constants and mapping (`0`=System, `1`=Heating, `2`=Cooling, `3`=DHW, `4`=App, `5`=None)
- Add `examples/system_state.py` CLI that displays the system hierarchy

## Example output
```
  ECO-0600 System State  (AECO-0982)
  ========================================

  *** WEATHER SHUTDOWN ACTIVE: WWSD ***

  >>> Heat Demand [ON]
        Tank: 96.3°F / target 90.0°F  [WWSD]
        Stages: 1 enabled, none running
        Reversing Valve: [off]
        Pump 1: [off]  mode=heating

      Cool Demand [off]
        Tank: 96.3°F / target 90.0°F

      DHW Demand [off]
        Tank: 120.8°F / target 119.0°F
        Pump 2: [off]  mode=dhw

  Outdoor: 80.8°F
```

## Test plan
- [x] All 704 existing + new unit tests pass
- [x] Verified `get_system_state()` against live API
- [x] Example CLI tested against live device

🤖 Generated with [Claude Code](https://claude.com/claude-code)