### PR TITLE
fix: guard empty discovery lists in system_state example + add regression tests

### DIFF
--- a/examples/system_state.py
+++ b/examples/system_state.py
@@ -162,9 +162,15 @@ async def main():
         # Auto-discover building and device if not specified
         if not building_id:
             buildings = await api.get_buildings()
+            if not buildings:
+                print("No buildings found on this account. Set SENSORLINX_BUILDING_ID to specify one.", file=sys.stderr)
+                sys.exit(1)
             building_id = buildings[0]["id"]
         if not device_id:
             devices = await api.get_devices(building_id)
+            if not devices:
+                print(f"No devices found in building {building_id}. Set SENSORLINX_DEVICE_ID to specify one.", file=sys.stderr)
+                sys.exit(1)
             device_id = devices[0]["syncCode"]
 
         device = SensorlinxDevice(api, building_id, device_id)

--- a/tests/get_parameter_test.py
+++ b/tests/get_parameter_test.py
@@ -1114,6 +1114,43 @@ async def test_get_system_state_pump_unknown_mode():
     assert result['pumps'][0]['mode'] == 'unknown (99)'
 
 
+@pytest.mark.get_params
+async def test_get_dhw_state_tolerates_sparse_demand_entry():
+    """Regression guard: get_dhw_state must handle an upstream DHW demand
+    that is missing optional fields. If get_demands' default-supplying
+    contract is ever weakened, this test will catch the resulting KeyError.
+    """
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    # Upstream returns a dhw entry with only 'name' — all other fields absent.
+    sparse_info = {"demands": [{"name": "dhw"}]}
+
+    result = await device.get_dhw_state(device_info=sparse_info)
+    assert result == {"activated": False, "enabled": False, "title": ""}
+
+
+@pytest.mark.get_params
+async def test_get_demands_supplies_defaults_for_sparse_entries():
+    """Regression guard: get_demands must always return dicts with all
+    four canonical keys (activated, enabled, name, title), even when the
+    upstream API omits fields. get_dhw_state and get_system_state depend
+    on this contract.
+    """
+    sensorlinx = Sensorlinx()
+    device = SensorlinxDevice(sensorlinx, "building123", "device456")
+
+    info = {"demands": [{"name": "hd"}, {"name": "cd"}, {"name": "dhw"}]}
+    result = await device.get_demands(device_info=info)
+
+    assert len(result) == 3
+    for entry in result:
+        assert set(entry.keys()) == {"activated", "enabled", "name", "title"}
+        assert entry["activated"] is False
+        assert entry["enabled"] is False
+        assert entry["title"] == ""
+
+
 SAMPLE_BUILDING_INFO= {
     "weather": {
         "weather": {


### PR DESCRIPTION
Follow-up polish on #16 (which was merged).

## Changes

**examples/system_state.py** - Auto-discovery now errors cleanly when the account has no buildings or the selected building has no devices, instead of raising a bare `IndexError` on `buildings[0]["id"]` / `devices[0]["syncCode"]`. Suggests the env var the user can set to bypass discovery.

**tests/get_parameter_test.py** - Two small regression guards for the `get_dhw_state` refactor introduced in #16:

1. `test_get_dhw_state_tolerates_sparse_demand_entry` - verifies `get_dhw_state` still works when the upstream DHW demand is missing optional fields. Currently passes because `get_demands()` supplies `.get()` defaults, but pins that contract.

2. `test_get_demands_supplies_defaults_for_sparse_entries` - pins the contract that `get_demands` always returns all four canonical keys. If anyone later weakens those defaults, `get_dhw_state` / `get_system_state` would silently break; this test catches it at unit-test time.

## Test plan
- [x] `pytest tests/get_parameter_test.py` - 123 passed (was 121)
