### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysensorlinx"          
-version = "0.2.1"             
+version = "0.2.2"             
 description = "Python library for accessing SensorLinx Device Data"
 readme = "README.md"          
 license = { text = "MIT" }    


### PR DESCRIPTION
v0.2.1 already exists on PyPI/tags. Bumping to 0.2.2 so the first auto-release from the new pipeline can publish.