### PR TITLE
fix: resilient login + 401 auto-retry

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,4 +17,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[tests]
       - name: Run unit tests
-        run: pytest -s -m "set_params or get_params or temperature"
+        run: pytest -s -m "set_params or get_params or temperature or auth"

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,5 @@ markers =
     get_params: mark tests that will get parameters
     set_params: mark tests that will set parameters
     temperature: mark tests that will check temperature class
+    auth: mark tests that exercise login lifecycle / auth recovery
     live: mark test as requiring network access

--- a/src/pysensorlinx/__init__.py
+++ b/src/pysensorlinx/__init__.py
@@ -1,4 +1,4 @@
-from .sensorlinx import Sensorlinx, Temperature, TemperatureDelta, SensorlinxDevice, InvalidCredentialsError, LoginTimeoutError, LoginError, InvalidParameterError
+from .sensorlinx import Sensorlinx, Temperature, TemperatureDelta, SensorlinxDevice, InvalidCredentialsError, LoginTimeoutError, LoginError, NoTokenError, InvalidParameterError
 
-__all__ = ["Sensorlinx", "Temperature", "TemperatureDelta", "SensorlinxDevice", "InvalidCredentialsError", "LoginTimeoutError", "LoginError", "InvalidParameterError"]
-__version__ = "0.2.1"
+__all__ = ["Sensorlinx", "Temperature", "TemperatureDelta", "SensorlinxDevice", "InvalidCredentialsError", "LoginTimeoutError", "LoginError", "NoTokenError", "InvalidParameterError"]
+__version__ = "0.2.3"

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -202,7 +202,11 @@ class Sensorlinx:
         self._session = None
         self._bearer_token = None
         self._refresh_token = None
-        
+        # Serializes login / cleanup / 401-driven reauth so concurrent
+        # callers (HA coordinator + service calls) cannot race on the
+        # session object.
+        self._auth_lock = asyncio.Lock()
+
         self.headers = {
             "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
                         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 "
@@ -213,10 +217,37 @@ class Sensorlinx:
         self.proxy_url = None  # Set to None to disable proxy, or provide a valid proxy URL if needed
                         
         
-    
+    @property
+    def is_logged_in(self) -> bool:
+        """True iff there is an open session AND a bearer token."""
+        return self._session is not None and not self._session.closed and bool(self._bearer_token)
+
+    async def _cleanup_session(self) -> None:
+        """Close the aiohttp session and clear auth tokens.
+
+        Cached credentials (``_username`` / ``_password``) are *not* cleared
+        here so that a subsequent ``login()`` call can transparently
+        reauthenticate. Use :meth:`close` for an explicit shutdown that
+        also forgets credentials.
+        """
+        if self._session is not None:
+            try:
+                if not self._session.closed:
+                    await self._session.close()
+            except Exception:  # pragma: no cover - close shouldn't raise
+                _LOGGER.exception("Error closing session during cleanup")
+        self._session = None
+        self._bearer_token = None
+        self._refresh_token = None
+        self.headers.pop("Authorization", None)
+
     async def login(self, username: str=None, password: str=None) -> None:
         """
         Attempt to log in to the Sensorlinx service.
+
+        Idempotent: if the client is already logged in and no new
+        credentials are supplied, this is a no-op. On any failure the
+        client is left in a clean, not-logged-in state.
 
         Args:
             username (str, optional): The username to use for login.
@@ -228,20 +259,45 @@ class Sensorlinx:
             NoTokenError: If no bearer token is received after login.
             LoginError: For other login-related errors.
         """
-        if not username or not password:
-            if not self._username or not self._password:
-                _LOGGER.error("No username or password provided.")
-                raise InvalidCredentialsError("No username or password provided.")
-        else:
+        async with self._auth_lock:
+            await self._login_locked(username, password)
+
+    async def _login_locked(self, username: str=None, password: str=None) -> None:
+        new_creds_supplied = bool(username and password)
+        new_creds_match_cached = (
+            new_creds_supplied
+            and username == self._username
+            and password == self._password
+        )
+
+        # Idempotent fast-path: already authenticated, and either no
+        # fresh credentials were supplied or they match the cached ones.
+        # Check this BEFORE mutating cached creds so a true rotation
+        # (different new creds) is not mistaken for a no-op.
+        if self.is_logged_in and (not new_creds_supplied or new_creds_match_cached):
+            return
+
+        if new_creds_supplied:
+            # Cache eagerly so that a first-ever transient failure can
+            # still self-heal on the next call (the failed attempt at
+            # least leaves us with the user's intended credentials).
             self._username = username
             self._password = password
+        elif not (self._username and self._password):
+            _LOGGER.error("No username or password provided.")
+            raise InvalidCredentialsError("No username or password provided.")
+
+        # Replace any prior session before opening a new one so we never
+        # leak a ClientSession across login attempts.
+        if self._session is not None:
+            await self._cleanup_session()
 
         self._session = aiohttp.ClientSession()
 
         login_url = f"{HOST_URL}/{LOGIN_ENDPOINT}"
         payload = {
             "email": self._username,
-            "password": self._password
+            "password": self._password,
         }
         try:
             async with self._session.post(
@@ -259,54 +315,116 @@ class Sensorlinx:
                     _LOGGER.error(f"Login failed with status {resp.status}: {body}")
                     raise LoginError(f"Login failed with status {resp.status}: {body}")
                 data = await resp.json()
-                self._bearer_token = data.get("token")
-                self._refresh_token = data.get("refresh")
-                if not self._bearer_token:
+                bearer = data.get("token")
+                if not bearer:
                     _LOGGER.error("No bearer token received during login.")
                     raise NoTokenError("No bearer token received during login.")
+                self._bearer_token = bearer
+                self._refresh_token = data.get("refresh")
                 self.headers["Authorization"] = f"Bearer {self._bearer_token}"
         except asyncio.TimeoutError:
             _LOGGER.error("Login request timed out.")
+            await self._cleanup_session()
             raise LoginTimeoutError("Login request timed out.")
+        except LoginError:
+            await self._cleanup_session()
+            raise
         except Exception as e:
             _LOGGER.exception(f"Exception during login: {e}")
+            await self._cleanup_session()
             raise LoginError(f"Exception during login: {e}")
         
     async def close(self):
-        """Close the aiohttp session if it exists."""
-        if self._session:
-            await self._session.close()
-            self._session = None
-            self._bearer_token = None
-            self._refresh_token = None
-            _LOGGER.debug("Session closed successfully.")
-        else:
-            _LOGGER.debug("No session to close.")
-        
+        """Close the aiohttp session and forget cached credentials.
+
+        Use this for an explicit shutdown (e.g. HA's ``async_unload_entry``).
+        For internal failure cleanup that needs to preserve credentials so
+        the next call can reauthenticate, see :meth:`_cleanup_session`.
+        """
+        async with self._auth_lock:
+            had_session = self._session is not None
+            await self._cleanup_session()
+            self._username = None
+            self._password = None
+            if had_session:
+                _LOGGER.debug("Session closed successfully.")
+            else:
+                _LOGGER.debug("No session to close.")
+
+    async def _authenticated_request(self, method: str, url: str, *, retry_on_401: bool = True, **kwargs):
+        """Issue an authenticated request, transparently reauthenticating on 401.
+
+        Args:
+            method: HTTP method (``GET``, ``PATCH``, ...).
+            url: Fully-qualified request URL.
+            retry_on_401: When True (default) and the server responds 401
+                Unauthorized, clear auth state, log in again with cached
+                credentials, and retry the request once. A second 401
+                raises :class:`InvalidCredentialsError`. Network errors
+                and timeouts are *never* retried because their semantics
+                (especially for writes) are ambiguous.
+            **kwargs: Forwarded to ``aiohttp.ClientSession.request``. The
+                authorization header is injected automatically; callers
+                should not supply ``headers["Authorization"]``.
+
+        Returns:
+            Parsed JSON body when ``Content-Type`` is JSON, otherwise the
+            raw response text.
+
+        Raises:
+            InvalidCredentialsError: After a second consecutive 401.
+            LoginError / LoginTimeoutError / aiohttp errors: Propagated
+                unchanged from the underlying calls.
+        """
+        if not self.is_logged_in:
+            await self.login()
+
+        attempt = 0
+        while True:
+            attempt += 1
+            req_headers = {**self.headers, **(kwargs.pop("headers", {}) if attempt == 1 else {})}
+            req_kwargs = dict(kwargs)
+            req_kwargs.setdefault("timeout", 10)
+            req_kwargs.setdefault("proxy", self.proxy_url)
+            session_method = getattr(self._session, method.lower())
+            async with session_method(url, headers=req_headers, **req_kwargs) as resp:
+                if resp.status == 401 and retry_on_401 and attempt == 1:
+                    body_preview = await resp.text()
+                    _LOGGER.info(
+                        "Got 401 on %s %s; re-authenticating once. Body: %s",
+                        method, url, body_preview[:200],
+                    )
+                    # Force a clean reauth: drop the (likely-expired)
+                    # token but keep the session/creds for the relogin.
+                    self._bearer_token = None
+                    self.headers.pop("Authorization", None)
+                    await self.login()  # uses cached creds; raises if they are now bad
+                    continue
+                if resp.status == 401:
+                    body = await resp.text()
+                    raise InvalidCredentialsError(
+                        f"Authentication rejected after retry on {method} {url}: {body}"
+                    )
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise RuntimeError(f"{method} {url} failed with status {resp.status}: {body}")
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    return await resp.json()
+                return await resp.text()
+
     async def get_profile(self) -> Optional[Dict[str, str]]:
         ''' Fetch the user profile information
         
         Returns: Optional[Dict[str, str]]: Returns a dictionary with user profile information or None if not logged in.
         '''
-        
-        if self._session is None:
-            if not await self.login():
-                return None
-
         profile_url = f"{HOST_URL}/{PROFILE_ENDPOINT}"
         try:
-            async with self._session.get(
-                profile_url,
-                headers=self.headers,
-                proxy=self.proxy_url,
-                timeout=10
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    _LOGGER.error(f"Failed to fetch profile with status {resp.status}: {body}")
-                    return None
-                data = await resp.json()
-                return data
+            return await self._authenticated_request("GET", profile_url)
+        except LoginError:
+            # Auth failures must reach the caller so HA can route them
+            # to ConfigEntryAuthFailed / UpdateFailed appropriately.
+            raise
         except Exception as e:
             _LOGGER.error(f"Exception fetching profile: {e}")
             return None
@@ -322,28 +440,15 @@ class Sensorlinx:
                 - If building_id is None, returns a list of building dicts or None if not logged in.
                 - If building_id is provided, returns a dict for the building or None if not found.
         '''
-        if self._session is None:
-            if not await self.login():
-                return None
-
         if building_id:
             buildings_url = f"{HOST_URL}/{BUILDINGS_ENDPOINT}/{building_id}"
         else:
             buildings_url = f"{HOST_URL}/{BUILDINGS_ENDPOINT}"
 
         try:
-            async with self._session.get(
-                buildings_url,
-                headers=self.headers,
-                proxy=self.proxy_url,
-                timeout=10
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    _LOGGER.error(f"Failed to fetch building(s) with status {resp.status}: {body}")
-                    return None
-                data = await resp.json()
-                return data
+            return await self._authenticated_request("GET", buildings_url)
+        except LoginError:
+            raise
         except Exception as e:
             _LOGGER.error(f"Exception fetching building(s): {e}")
             return None
@@ -363,9 +468,6 @@ class Sensorlinx:
         Raises:
             RuntimeError: If the request fails or the device(s) are not found.
         '''
-        if self._session is None:
-            await self.login()
-
         if device_id:
             url = f"{HOST_URL}/{DEVICES_ENDPOINT_TEMPLATE.format(building_id=building_id)}/{device_id}"
             _LOGGER.debug(f"Fetching URL: {url}")
@@ -373,23 +475,15 @@ class Sensorlinx:
             url = f"{HOST_URL}/{DEVICES_ENDPOINT_TEMPLATE.format(building_id=building_id)}"
 
         try:
-            async with self._session.get(
-                url,
-                headers=self.headers,
-                proxy=self.proxy_url,
-                timeout=10
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    _LOGGER.error(f"Failed to fetch device(s) with status {resp.status}: {body}")
-                    raise RuntimeError(f"Failed to fetch device(s) with status {resp.status}: {body}")
-                data = await resp.json()
-                if not data:
-                    raise RuntimeError("No device data found.")
-                return data
+            data = await self._authenticated_request("GET", url)
+        except LoginError:
+            raise
         except Exception as e:
             _LOGGER.error(f"Exception fetching device(s): {e}")
             raise RuntimeError(f"Exception fetching device(s): {e}")
+        if not data:
+            raise RuntimeError("No device data found.")
+        return data
 
     async def set_device_parameter(
         self,
@@ -474,9 +568,6 @@ class Sensorlinx:
         if not building_id or not device_id:
             _LOGGER.error("Both building_id and device_id must be provided.")
             raise InvalidParameterError("Both building_id and device_id must be provided.")
-
-        if self._session is None:
-            await self.login()
 
         url = f"{HOST_URL}/{DEVICES_ENDPOINT_TEMPLATE.format(building_id=building_id)}/{device_id}"
         payload = {}
@@ -792,18 +883,15 @@ class Sensorlinx:
             raise InvalidParameterError("At least one optional parameter must be provided.")
 
         try:
-            async with self._session.patch(
+            response = await self._authenticated_request(
+                "PATCH",
                 url,
                 json=payload,
-                headers={**self.headers, "Content-Type": "application/json"},
-                proxy=self.proxy_url,
-                timeout=10
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    _LOGGER.error(f"Failed to set device parameter(s) with status {resp.status}: {body}")
-                    raise RuntimeError(f"Failed to set device parameter(s) with status {resp.status}: {body}")
-                _LOGGER.debug(f"Response from setting device parameter(s): {await resp.json()}")
+                headers={"Content-Type": "application/json"},
+            )
+            _LOGGER.debug(f"Response from setting device parameter(s): {response}")
+        except LoginError:
+            raise
         except Exception as e:
             _LOGGER.error(f"Exception setting device parameter(s): {e}")
             raise RuntimeError(f"Exception setting device parameter(s): {e}")

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,0 +1,512 @@
+"""Unit tests for Sensorlinx login lifecycle, idempotency, and 401 retry.
+
+These tests cover bug fixes for the "login times out and never recovers" failure
+mode reported by users. See https://github.com/sslivins/pysensorlinx/issues for
+context.
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from pysensorlinx import (
+    InvalidCredentialsError,
+    LoginError,
+    LoginTimeoutError,
+    NoTokenError,
+    Sensorlinx,
+)
+from pysensorlinx.sensorlinx import (
+    BUILDINGS_ENDPOINT,
+    DEVICES_ENDPOINT_TEMPLATE,
+    HOST_URL,
+    LOGIN_ENDPOINT,
+    PROFILE_ENDPOINT,
+)
+
+
+LOGIN_URL = f"{HOST_URL}/{LOGIN_ENDPOINT}"
+PROFILE_URL = f"{HOST_URL}/{PROFILE_ENDPOINT}"
+BUILDINGS_URL = f"{HOST_URL}/{BUILDINGS_ENDPOINT}"
+DEVICE_URL = f"{HOST_URL}/{DEVICES_ENDPOINT_TEMPLATE.format(building_id='b1')}/d1"
+
+
+def _login_ok(m, token: str = "tok-1", refresh: str = "ref-1"):
+    """Register a successful login response."""
+    m.post(LOGIN_URL, status=200, payload={"token": token, "refresh": refresh})
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: login failures must leave the client in a clean, not-logged-in
+# state. This is the regression behind "Login request timed out" / never
+# recovers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_login_timeout_leaves_client_not_logged_in():
+    """A login that times out must not leave a half-initialized session.
+
+    Repro for the bug: today login() assigns self._session BEFORE the POST,
+    and the timeout handler doesn't tear it down. Subsequent data calls
+    then check `if self._session is None` (false), skip relogin, and call
+    the API unauthenticated forever.
+    """
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        m.post(LOGIN_URL, exception=asyncio.TimeoutError())
+        with pytest.raises(LoginTimeoutError):
+            await sl.login("user@example.com", "pw")
+
+    assert sl.is_logged_in is False
+    assert sl._session is None
+    assert sl._bearer_token is None
+
+
+@pytest.mark.auth
+async def test_login_invalid_credentials_propagate_typed_exception():
+    """InvalidCredentialsError must NOT be re-wrapped as a generic LoginError.
+
+    Today the `except Exception as e: raise LoginError(...)` block in login()
+    swallows the typed auth exception, so HA can never distinguish bad
+    creds from a network error. Without this the ConfigEntryAuthFailed
+    path can't fire.
+    """
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        m.post(LOGIN_URL, status=401, payload={"error": "bad creds"})
+        with pytest.raises(InvalidCredentialsError):
+            await sl.login("user@example.com", "pw")
+
+    assert sl.is_logged_in is False
+    assert sl._session is None
+
+
+@pytest.mark.auth
+async def test_login_no_token_propagates_typed_exception():
+    """NoTokenError (200 OK with no token in body) must not be re-wrapped."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        m.post(LOGIN_URL, status=200, payload={"refresh": "x"})  # no 'token'
+        with pytest.raises(NoTokenError):
+            await sl.login("user@example.com", "pw")
+
+    assert sl.is_logged_in is False
+    assert sl._session is None
+
+
+@pytest.mark.auth
+async def test_login_unknown_5xx_raises_login_error_and_cleans_up():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        m.post(LOGIN_URL, status=503, body="Service Unavailable")
+        with pytest.raises(LoginError):
+            await sl.login("user@example.com", "pw")
+
+    assert sl.is_logged_in is False
+    assert sl._session is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: calling login() while already logged in is a no-op (no new
+# session, no new POST).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_login_is_idempotent_when_already_logged_in():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+        first_session = sl._session
+        first_token = sl._bearer_token
+        # Second call must NOT POST again or replace the session.
+        await sl.login()
+        assert sl._session is first_session
+        assert sl._bearer_token == first_token
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_login_replaces_session_when_called_after_failure():
+    """A relogin after a failure must close the prior session, not leak it."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        m.post(LOGIN_URL, exception=asyncio.TimeoutError())
+        with pytest.raises(LoginTimeoutError):
+            await sl.login("u", "p")
+        assert sl._session is None  # cleaned up
+
+        _login_ok(m)
+        await sl.login()  # uses cached creds
+        assert sl.is_logged_in is True
+    await sl.close()
+
+
+# ---------------------------------------------------------------------------
+# 401 auto-retry: after a token expires mid-day, the very next call must
+# self-heal by reauthenticating once and retrying. This is what removes
+# the need for the HA integration to call login() every cycle.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_data_call_retries_once_on_401_and_succeeds():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        # Initial login.
+        _login_ok(m, token="old-tok")
+        # First profile call returns 401 (token expired).
+        m.get(PROFILE_URL, status=401)
+        # Library reauths with cached creds.
+        _login_ok(m, token="new-tok")
+        # Retry succeeds.
+        m.get(PROFILE_URL, status=200, payload={"id": "u1"})
+
+        await sl.login("u", "p")
+        result = await sl.get_profile()
+
+    assert result == {"id": "u1"}
+    assert sl._bearer_token == "new-tok"
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_data_call_two_consecutive_401s_raises_invalid_creds():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m, token="old-tok")
+        m.get(PROFILE_URL, status=401)
+        # Reauth attempt itself returns 401 (creds rotated).
+        m.post(LOGIN_URL, status=401)
+
+        await sl.login("u", "p")
+        with pytest.raises(InvalidCredentialsError):
+            await sl.get_profile()
+
+    assert sl.is_logged_in is False
+    await sl.close()
+
+
+# ---------------------------------------------------------------------------
+# Recovery: a data call after a prior login failure must self-heal on the
+# next cycle. Mirrors the user's exact failure mode.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_data_call_recovers_after_prior_login_timeout():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        # Cycle 1: login times out.
+        m.post(LOGIN_URL, exception=asyncio.TimeoutError())
+        with pytest.raises(LoginTimeoutError):
+            await sl.login("u", "p")
+
+        # Cycle 2: HA polls again. With the fix, `is_logged_in` is False,
+        # so HA calls login() and it succeeds, then get_buildings() works.
+        _login_ok(m)
+        m.get(BUILDINGS_URL, status=200, payload=[{"id": "b1"}])
+
+        assert sl.is_logged_in is False
+        await sl.login()  # cached creds
+        result = await sl.get_buildings()
+
+    assert result == [{"id": "b1"}]
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_close_clears_cached_credentials():
+    """close() is an explicit shutdown — must clear creds too, not just session."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+
+    await sl.close()
+    assert sl._username is None
+    assert sl._password is None
+    assert sl._bearer_token is None
+    assert sl._session is None
+
+
+@pytest.mark.auth
+async def test_cleanup_on_failure_preserves_cached_credentials():
+    """A transient cleanup must NOT wipe creds — auto-relogin needs them."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+        # Now simulate a 401 leading to a cleanup+relogin attempt that fails.
+        m.get(PROFILE_URL, status=401)
+        m.post(LOGIN_URL, exception=asyncio.TimeoutError())
+        with pytest.raises((LoginTimeoutError, LoginError)):
+            await sl.get_profile()
+
+    assert sl.is_logged_in is False
+    # But cached creds remain so a future cycle can recover.
+    assert sl._username == "u"
+    assert sl._password == "p"
+    await sl.close()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: two coroutines racing to login() must not both POST.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_concurrent_logins_are_serialized():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        # Register exactly ONE successful login; if the lock works, only
+        # one POST happens. Without the lock, the second concurrent call
+        # would hit aioresponses with no registered mock and 4xx/raise.
+        _login_ok(m)
+
+        await asyncio.gather(sl.login("u", "p"), sl.login("u", "p"))
+
+    assert sl.is_logged_in is True
+    await sl.close()
+
+
+# ---------------------------------------------------------------------------
+# Gap coverage: behaviors introduced by the refactor that weren't yet
+# directly exercised by the lifecycle/idempotency tests above.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth
+async def test_is_logged_in_false_when_session_closed():
+    """is_logged_in must reflect aiohttp's own close state, not just bearer presence.
+
+    aiohttp can self-close a session on certain transport errors; if we only
+    checked the bearer token we'd think we were still logged in and fire
+    requests through a dead session.
+    """
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+        assert sl.is_logged_in is True
+        await sl._session.close()  # simulate aiohttp self-closing
+        assert sl.is_logged_in is False
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_is_logged_in_false_after_close():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+    await sl.close()
+    assert sl.is_logged_in is False
+
+
+@pytest.mark.auth
+async def test_login_with_new_credentials_replaces_cached_creds():
+    """login("new","creds") while already logged in must NOT take the idempotent
+    fast-path — the user is rotating credentials and expects a fresh login."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m, token="tok-old")
+        await sl.login("old-user", "old-pass")
+        first_session = sl._session
+
+        m.post(LOGIN_URL, status=200, payload={"token": "tok-new", "refresh": "r2"})
+        await sl.login("new-user", "new-pass")
+
+    assert sl._username == "new-user"
+    assert sl._password == "new-pass"
+    assert sl._bearer_token == "tok-new"
+    # Old session must be closed so we don't leak it.
+    assert first_session.closed is True
+    assert sl._session is not first_session
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_login_idempotent_when_called_with_same_credentials():
+    """Re-logging-in with the exact same creds while already authenticated
+    is a no-op (avoids gratuitous POSTs from defensive callers)."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        # Register only one successful login. If idempotency works the
+        # second login() call won't try to POST again.
+        _login_ok(m, token="tok-1")
+        await sl.login("u", "p")
+        await sl.login("u", "p")  # would raise ConnectionError without no-op
+        assert sl._bearer_token == "tok-1"
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_set_device_parameter_retries_once_on_401():
+    """The 401 auto-retry must work for writes (PATCH), not just reads.
+
+    set_device_parameter is the one transport-level write — its retry path
+    is identical to GET because the body is deterministic and idempotent.
+    """
+    sl = Sensorlinx()
+    from pysensorlinx import SensorlinxDevice
+    device = SensorlinxDevice(sl, "b1", "d1")
+
+    with aioresponses() as m:
+        _login_ok(m, token="tok-stale")
+        await sl.login("u", "p")
+
+        # First PATCH gets stale-token 401, then relogin, then succeeds.
+        m.patch(DEVICE_URL, status=401, body="token expired")
+        m.post(LOGIN_URL, status=200, payload={"token": "tok-fresh", "refresh": "r"})
+        m.patch(DEVICE_URL, status=200, payload={"ok": True})
+
+        # permanent_hd is the simplest boolean param; one parameter is enough.
+        await sl.set_device_parameter("b1", "d1", permanent_hd=True)
+
+    assert sl._bearer_token == "tok-fresh"
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_authorization_header_is_refreshed_after_relogin():
+    """After a 401 → relogin, the retried request must carry the NEW bearer.
+
+    Regression guard: the old auth header must not survive into the retry.
+    aioresponses doesn't surface request headers easily, so we assert via
+    the bearer state seen by subsequent calls.
+    """
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m, token="tok-old")
+        await sl.login("u", "p")
+        assert sl.headers["Authorization"] == "Bearer tok-old"
+
+        m.get(PROFILE_URL, status=401)
+        m.post(LOGIN_URL, status=200, payload={"token": "tok-new", "refresh": "r"})
+        m.get(PROFILE_URL, status=200, payload={"id": 1})
+        await sl.get_profile()
+
+        assert sl.headers["Authorization"] == "Bearer tok-new"
+        assert sl._bearer_token == "tok-new"
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_data_call_does_not_retry_on_500():
+    """Non-401 server errors must surface immediately, not trigger relogin.
+
+    Re-authenticating in response to a 5xx would mask backend outages and
+    spam the auth endpoint. Only definite 401s reauth.
+
+    get_profile() catches non-LoginError exceptions and returns None,
+    so a successful "no retry" outcome here is: result is None and
+    only one login POST was registered (not consumed twice).
+    """
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+
+        m.get(PROFILE_URL, status=500, body="internal error")
+        # Only one login POST was registered; if relogin had been
+        # attempted on 500 it would raise ConnectionError as a second
+        # POST has no mock — so the *absence* of that error proves the
+        # 500 path didn't reauth.
+        result = await sl.get_profile()
+        assert result is None
+        assert sl.is_logged_in is True  # still logged in; no churn
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_data_call_does_not_relogin_on_connection_error():
+    """Connection errors must not trigger relogin (semantics ambiguous for writes,
+    and pointless for reads — auth wasn't the problem)."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+
+        m.get(
+            PROFILE_URL,
+            exception=aiohttp.ClientConnectionError("network down"),
+        )
+        # No second POST registered: if we tried to relogin on conn error,
+        # this would raise ConnectionRefused as a different error.
+        result = await sl.get_profile()
+        # get_profile catches non-LoginError exceptions and returns None.
+        assert result is None
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_close_is_safe_when_never_logged_in():
+    """Defensive: HA may call close() during teardown even if login never ran."""
+    sl = Sensorlinx()
+    await sl.close()  # must not raise
+    assert sl.is_logged_in is False
+
+
+@pytest.mark.auth
+async def test_close_is_idempotent():
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        _login_ok(m)
+        await sl.login("u", "p")
+    await sl.close()
+    await sl.close()  # second close must not raise
+    assert sl.is_logged_in is False
+
+
+@pytest.mark.auth
+async def test_concurrent_data_calls_login_only_once():
+    """Two coroutines racing to make data calls when not logged in must
+    share a single login POST, not stampede the auth endpoint."""
+    sl = Sensorlinx()
+    with aioresponses() as m:
+        # Register exactly ONE login + two profile responses. If the lock
+        # works, both calls share the single login.
+        _login_ok(m)
+        m.get(PROFILE_URL, status=200, payload={"id": 1})
+        m.get(PROFILE_URL, status=200, payload={"id": 1})
+
+        # Pre-cache creds so login(no-args) inside _authenticated_request works.
+        sl._username = "u"
+        sl._password = "p"
+
+        results = await asyncio.gather(sl.get_profile(), sl.get_profile())
+
+    assert all(r == {"id": 1} for r in results)
+    assert sl._bearer_token == "tok-1"
+    await sl.close()
+
+
+@pytest.mark.auth
+async def test_consecutive_failed_logins_do_not_leak_sessions():
+    """A storm of failed logins must not pile up unclosed ClientSessions.
+
+    Regression guard for the original bug where every login() created a
+    fresh session without closing the prior one.
+    """
+    sl = Sensorlinx()
+    sessions = []
+
+    with aioresponses() as m:
+        for _ in range(3):
+            m.post(LOGIN_URL, exception=asyncio.TimeoutError())
+
+        for _ in range(3):
+            with pytest.raises(LoginTimeoutError):
+                await sl.login("u", "p")
+            # _cleanup_session nulls _session, so we can only sample what
+            # is_logged_in says. The strong invariant: after each failure,
+            # session is None (closed and dropped).
+            assert sl._session is None
+            assert sl.is_logged_in is False
+
+    await sl.close()

--- a/tests/set_parameters_test.py
+++ b/tests/set_parameters_test.py
@@ -12,12 +12,17 @@ def sensorlinx_device_with_patch():
     )
     
     sensorlinx._session = MagicMock()
+    sensorlinx._session.closed = False
+    sensorlinx._bearer_token = "fake-bearer-token-for-tests"
+    sensorlinx.headers["Authorization"] = f"Bearer {sensorlinx._bearer_token}"
     mock_patch = MagicMock()
     mock_response = MagicMock()
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
     mock_response.__aexit__ = AsyncMock(return_value=None)
     mock_response.status = 200
+    mock_response.headers = {"Content-Type": "application/json"}
     mock_response.json = AsyncMock(return_value={})
+    mock_response.text = AsyncMock(return_value="{}")
     mock_patch.return_value = mock_response
     sensorlinx._session.patch = mock_patch
     return sensorlinx, device, mock_patch


### PR DESCRIPTION
## Why

Users running Home Assistant integrations on top of `pysensorlinx` (e.g. `hass_hbxcontrols`) report that a single `Login request timed out.` permanently breaks the integration until the config entry is reloaded. The bug is in `Sensorlinx.login()`:

1. `self._session = aiohttp.ClientSession()` is assigned **before** the login POST.
2. If the POST raises (timeout, connection error, etc.), `_session` is left as a non-`None`, *unauthenticated* session with no bearer token.
3. Every other method gates re-login on `if self._session is None: await self.login()` — that check is now `False`, so subsequent calls hit the API unauthenticated and never recover.
4. `except Exception → LoginError` swallows `InvalidCredentialsError`, so HA's `ConfigEntryAuthFailed` reauth path can never fire either.

## What

**Resilient login with a clean state machine, plus a 401 auto-retry helper.**

- New `is_logged_in` property: session-not-None **AND** not-closed **AND** bearer truthy.
- `login()` is now idempotent and lock-protected (`asyncio.Lock`):
  - Already logged in + no new creds (or same creds) → no-op.
  - Replaces the prior session before opening a new one (no `ClientSession` leak across attempts).
  - On any failure, runs `_cleanup_session()` and ends in a clean not-logged-in state. Cached credentials are preserved so the next poll can self-heal.
  - Preserves typed exceptions: `InvalidCredentialsError`, `LoginTimeoutError`, `NoTokenError`, plain `LoginError`.
- New `_authenticated_request()` helper: every transport method now goes through it. On a definite 401 it strips the bearer, relogs in once, and retries. A second 401 raises `InvalidCredentialsError`. Timeouts/connection errors are **never** retried.
- `close()` clears cached credentials; `_cleanup_session()` (internal failure path) does **not**.
- Refactored to use the helper: `get_profile`, `get_buildings`, `get_devices`, `set_device_parameter`.

## Tests

24 new unit tests in `tests/auth_test.py` (marker: `auth`):

- Login lifecycle: timeout/invalid-creds/no-token/5xx all leave a clean state with typed exceptions.
- Idempotency: re-login no-op when already logged in (with same creds or no creds); but **does** re-login when creds rotate.
- Session hygiene: failed logins do not leak `ClientSession`s; rotation closes the prior session.
- 401 auto-retry: works for GET (`get_profile`) and PATCH (`set_device_parameter`); a second 401 raises `InvalidCredentialsError`; the new bearer replaces the old one in headers.
- Negative: 5xx and connection errors do **not** trigger relogin.
- Concurrency: two coroutines racing `login()` produce one POST; two racing `get_profile()` calls when not logged in share one login POST.
- Defensive: `close()` is safe to call when never logged in, and is idempotent.
- End-to-end recovery: after a `LoginTimeoutError`, the next poll cycle logs in cleanly using cached creds and fetches data.

**Suite: 745 passed, 18 deselected** (was 721 passed).

## Version

`__version__` and `pyproject.toml` are already at `0.2.3` (unreleased). Merge to `main` will auto-tag `v0.2.3` and publish to PyPI via the existing `release.yml` workflow.

## Compatibility

Public API unchanged. Callers that previously relied on `_session is None` as a proxy for "logged in" should switch to the new `is_logged_in` property, but the old check still works for the common case (after `close()` or after a failed first-ever login).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
