### PR TITLE
feat: add THM/ZON write setters (climate + ZON aux/app button) - 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysensorlinx"          
-version = "0.3.1"             
+version = "0.4.0"             
 description = "Python library for accessing SensorLinx Device Data"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -103,6 +103,30 @@ PUMP_MODES = {
     5: "none",
 }
 
+# THM/ZON device-specific raw field names (HBX cloud short keys).
+# Confirmed via paired before/after device dumps from a live install
+# (THM-0600 firmware 1.22, ZON-0600 firmware 1.32) on 2026-04-26.
+THM_CHANGEOVER = "cngOvr"      # 0=Auto, 1=Heat, 2=Cool, 3=Off
+THM_AWAY = "away"              # 0=off, 1=on
+THM_FAN_MODE = "fnMode"        # 0=Off, 1=On, 2=Intermittent
+THM_TARGET = "target"          # nested object {"value": int_F} for setpoint
+ZON_APP_BUTTON = "aBut"        # 0=off, 1=on
+ZON_DHW_TARGET = "dhwT"        # int °F (auxiliary heat / DHW setpoint)
+# ZON aux setpoint reuses the same `dhwT` key as ECO DHW target (see DHW_TARGET_TEMP).
+
+THM_CHANGEOVER_VALUES = {
+    "auto": 0,
+    "heat": 1,
+    "cool": 2,
+    "off": 3,
+}
+
+THM_FAN_MODE_VALUES = {
+    "off": 0,
+    "on": 1,
+    "intermittent": 2,
+}
+
 CONF_SITE_NAME = "site_name"       # The name of the site (e.g., "home")
 CONF_SENSOR_IDS = "sensor_ids"     # List of sensor IDs to extract (empty = all)
 CONF_USERNAME = "username"         # Login username
@@ -900,6 +924,58 @@ class Sensorlinx:
         except Exception as e:
             _LOGGER.error(f"Exception setting device parameter(s): {e}")
             raise RuntimeError(f"Exception setting device parameter(s): {e}")
+
+    async def patch_device(
+        self,
+        building_id: str,
+        device_id: str,
+        **fields,
+    ) -> None:
+        """
+        Send a low-level PATCH to the device-parameter endpoint with arbitrary
+        raw HBX field names.
+
+        Used for THM/ZON device-specific fields that aren't covered by the
+        typed signature of :py:meth:`set_device_parameter`. Reuses the same
+        URL and authentication path (including 401 retry).
+
+        Args:
+            building_id (str): The ID of the building (required).
+            device_id (str): The ID of the device (required).
+            **fields: Raw HBX field name -> value pairs. Example:
+                ``patch_device(b, d, cngOvr=1)`` to set THM changeover to Heat.
+
+        Raises:
+            InvalidParameterError: If ``building_id``/``device_id`` are missing
+                or no fields were supplied.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        if not building_id or not device_id:
+            _LOGGER.error("Both building_id and device_id must be provided.")
+            raise InvalidParameterError(
+                "Both building_id and device_id must be provided."
+            )
+        if not fields:
+            _LOGGER.error("At least one field must be provided to patch_device.")
+            raise InvalidParameterError(
+                "At least one field must be provided to patch_device."
+            )
+
+        url = f"{HOST_URL}/{DEVICES_ENDPOINT_TEMPLATE.format(building_id=building_id)}/{device_id}"
+        try:
+            response = await self._authenticated_request(
+                "PATCH",
+                url,
+                json=dict(fields),
+                headers={"Content-Type": "application/json"},
+            )
+            _LOGGER.debug(f"Response from patch_device: {response}")
+        except LoginError:
+            raise
+        except Exception as e:
+            _LOGGER.error(f"Exception in patch_device: {e}")
+            raise RuntimeError(f"Exception in patch_device: {e}")
 
            
 class SensorlinxDevice:
@@ -2769,8 +2845,10 @@ class ThmDevice(SensorlinxDevice):
     plus raw fields like ``rm`` (room °F), ``flr`` (floor °F), and
     ``hm`` (humidity %).
 
-    Only read-only accessors are provided; setters will be added once the
-    field-to-action mapping has been validated against a live device.
+    Most accessors are read-only; a small set of setters
+    (:meth:`set_hvac_mode`, :meth:`set_target_temperature`,
+    :meth:`set_away_mode`, :meth:`set_fan_mode`) cover the surfaces validated
+    against a live install.
     """
 
     async def get_name(self, device_info: Optional[Dict] = None) -> str:
@@ -2950,6 +3028,140 @@ class ThmDevice(SensorlinxDevice):
             raise RuntimeError("No matching temperature sensors found.")
         return result
 
+    # ------------------------------------------------------------------
+    # Setters
+    #
+    # Field names confirmed via paired before/after device dumps from a live
+    # THM-0600 (firmware 1.22) on 2026-04-26. ``set_target_temperature`` is
+    # the only setter whose payload shape is inferred (the change surfaced
+    # only in the derived ``target.value`` block in read-side data); all
+    # others write the raw integer field that demonstrably changed in the
+    # diffs.
+    # ------------------------------------------------------------------
+
+    async def set_hvac_mode(self, mode: str) -> None:
+        """
+        Set the THM changeover (HVAC mode).
+
+        Args:
+            mode: One of ``"auto"``, ``"heat"``, ``"cool"``, ``"off"``.
+
+        Raises:
+            InvalidParameterError: If ``mode`` is not recognised.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        key = mode.lower() if isinstance(mode, str) else None
+        if key not in THM_CHANGEOVER_VALUES:
+            _LOGGER.error(
+                "Invalid THM HVAC mode %r. Must be one of %s.",
+                mode, list(THM_CHANGEOVER_VALUES),
+            )
+            raise InvalidParameterError(
+                "Invalid THM HVAC mode. Must be 'auto', 'heat', 'cool' or 'off'."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_CHANGEOVER: THM_CHANGEOVER_VALUES[key]},
+        )
+
+    async def set_away_mode(self, enabled: bool) -> None:
+        """
+        Enable or disable the THM Away preset.
+
+        Args:
+            enabled: ``True`` to turn Away mode on; ``False`` to turn it off.
+
+        Raises:
+            InvalidParameterError: If ``enabled`` is not a bool.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        if not isinstance(enabled, bool):
+            _LOGGER.error("THM away mode must be a boolean (got %r).", type(enabled))
+            raise InvalidParameterError("THM away mode must be a boolean.")
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_AWAY: 1 if enabled else 0},
+        )
+
+    async def set_fan_mode(self, mode: str) -> None:
+        """
+        Set the THM fan mode.
+
+        Args:
+            mode: One of ``"off"``, ``"on"``, ``"intermittent"``.
+
+        Raises:
+            InvalidParameterError: If ``mode`` is not recognised.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        key = mode.lower() if isinstance(mode, str) else None
+        if key not in THM_FAN_MODE_VALUES:
+            _LOGGER.error(
+                "Invalid THM fan mode %r. Must be one of %s.",
+                mode, list(THM_FAN_MODE_VALUES),
+            )
+            raise InvalidParameterError(
+                "Invalid THM fan mode. Must be 'off', 'on' or 'intermittent'."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_FAN_MODE: THM_FAN_MODE_VALUES[key]},
+        )
+
+    async def set_target_temperature(self, value: Temperature) -> None:
+        """
+        Set the THM target setpoint for the active changeover (heat or cool).
+
+        The HBX backend determines which underlying field is updated based on
+        the current changeover state: when the THM is in Heat mode this
+        becomes the heat setpoint; in Cool mode it becomes the cool setpoint.
+        Calling this while the THM is in Off mode is rejected by the cloud.
+
+        Args:
+            value: A :class:`Temperature` in the 35°F–99°F range.
+
+        Raises:
+            InvalidParameterError: If ``value`` is not a Temperature or is
+                outside the safe range.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+
+        Note:
+            The payload shape (``{"target": {"value": int_F}}``) is inferred
+            from read-side dumps; if HBX rejects this with a 4xx the
+            implementation should be revisited. See
+            ``files/multi-replica-validation-loop.md`` for the field-mapping
+            history.
+        """
+        if not isinstance(value, Temperature):
+            _LOGGER.error(
+                "THM target temperature must be a Temperature instance (got %r).",
+                type(value),
+            )
+            raise InvalidParameterError(
+                "THM target temperature must be a Temperature instance."
+            )
+        temp_f = value.to_fahrenheit()
+        if not (35 <= temp_f <= 99):
+            _LOGGER.error(
+                "THM target temperature must be between 35°F and 99°F (got %s°F).",
+                temp_f,
+            )
+            raise InvalidParameterError(
+                "THM target temperature must be between 35°F and 99°F."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_TARGET: {"value": int(round(temp_f))}},
+        )
+
     async def _resolve_device_info(
         self, device_info: Optional[Dict] = None
     ) -> Dict:
@@ -2976,8 +3188,9 @@ class ZonDevice(SensorlinxDevice):
     available; use the linked :class:`ThmDevice` instances instead
     (see :meth:`get_thermostat_sync_codes`).
 
-    Only read-only accessors are provided; setters will be added once the
-    field-to-action mapping has been validated against a live device.
+    Most accessors are read-only; setters :meth:`set_app_button` and
+    :meth:`set_aux_setpoint` cover the surfaces validated against a live
+    install.
     """
 
     async def get_name(self, device_info: Optional[Dict] = None) -> str:
@@ -3078,6 +3291,75 @@ class ZonDevice(SensorlinxDevice):
         raise RuntimeError(
             "ZON devices do not expose temperatures directly; "
             "use the linked THM devices via get_thermostat_sync_codes()."
+        )
+
+    # ------------------------------------------------------------------
+    # Setters
+    #
+    # Field names confirmed via paired before/after device dumps from a live
+    # ZON-0600 (firmware 1.32) on 2026-04-26. Toggling ``aBut`` was observed
+    # to flip the 12th element of the relay state arrays as a hardware
+    # side-effect — that's a server-derived consequence and is not written.
+    # ``dhwT`` is the same field used by :class:`SensorlinxDevice` (ECO) for
+    # the DHW target setpoint.
+    # ------------------------------------------------------------------
+
+    async def set_app_button(self, enabled: bool) -> None:
+        """
+        Toggle the ZON "app button" (which drives relay 12).
+
+        Args:
+            enabled: ``True`` to activate the app button (and relay 12);
+                ``False`` to deactivate.
+
+        Raises:
+            InvalidParameterError: If ``enabled`` is not a bool.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        if not isinstance(enabled, bool):
+            _LOGGER.error("ZON app button must be a boolean (got %r).", type(enabled))
+            raise InvalidParameterError("ZON app button must be a boolean.")
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{ZON_APP_BUTTON: 1 if enabled else 0},
+        )
+
+    async def set_aux_setpoint(self, value: Temperature) -> None:
+        """
+        Set the ZON auxiliary heat setpoint.
+
+        Args:
+            value: A :class:`Temperature` in the 33°F–180°F range.
+
+        Raises:
+            InvalidParameterError: If ``value`` is not a Temperature or is
+                outside the safe range.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        if not isinstance(value, Temperature):
+            _LOGGER.error(
+                "ZON aux setpoint must be a Temperature instance (got %r).",
+                type(value),
+            )
+            raise InvalidParameterError(
+                "ZON aux setpoint must be a Temperature instance."
+            )
+        temp_f = value.to_fahrenheit()
+        if not (33 <= temp_f <= 180):
+            _LOGGER.error(
+                "ZON aux setpoint must be between 33°F and 180°F (got %s°F).",
+                temp_f,
+            )
+            raise InvalidParameterError(
+                "ZON aux setpoint must be between 33°F and 180°F."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{ZON_DHW_TARGET: int(round(temp_f))},
         )
 
     async def _resolve_device_info(

--- a/tests/thm_zon_setters_test.py
+++ b/tests/thm_zon_setters_test.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for the THM/ZON setters added in pysensorlinx 0.4.0.
+
+These tests use the same mocking pattern as ``set_parameters_test.py``:
+patch ``Sensorlinx._session.patch`` and assert on the JSON body that the
+setter sends. They confirm:
+
+* the right raw HBX field name is used (these are confirmed against live
+  device dumps from a THM-0600 / ZON-0600 — see the project plan for the
+  source of truth);
+* enum strings are translated to the right integer values;
+* range/type validation rejects bad inputs without making an HTTP call.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pysensorlinx import (
+    InvalidParameterError,
+    Sensorlinx,
+    Temperature,
+)
+from pysensorlinx.sensorlinx import ThmDevice, ZonDevice
+
+
+def _patched_sensorlinx():
+    sensorlinx = Sensorlinx()
+    sensorlinx._session = MagicMock()
+    sensorlinx._session.closed = False
+    sensorlinx._bearer_token = "fake-bearer-token-for-tests"
+    sensorlinx.headers["Authorization"] = f"Bearer {sensorlinx._bearer_token}"
+    mock_response = MagicMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+    mock_response.status = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json = AsyncMock(return_value={})
+    mock_response.text = AsyncMock(return_value="{}")
+    mock_patch = MagicMock(return_value=mock_response)
+    sensorlinx._session.patch = mock_patch
+    return sensorlinx, mock_patch
+
+
+@pytest.fixture
+def thm_with_patch():
+    sensorlinx, mock_patch = _patched_sensorlinx()
+    device = ThmDevice(
+        sensorlinx=sensorlinx,
+        building_id="building123",
+        device_id="thm456",
+    )
+    return sensorlinx, device, mock_patch
+
+
+@pytest.fixture
+def zon_with_patch():
+    sensorlinx, mock_patch = _patched_sensorlinx()
+    device = ZonDevice(
+        sensorlinx=sensorlinx,
+        building_id="building123",
+        device_id="zon789",
+    )
+    return sensorlinx, device, mock_patch
+
+
+# ---------------------------------------------------------------------------
+# THM: set_hvac_mode (cngOvr 0=Auto 1=Heat 2=Cool 3=Off)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("mode,expected", [
+    ("auto", {"cngOvr": 0}),
+    ("heat", {"cngOvr": 1}),
+    ("cool", {"cngOvr": 2}),
+    ("off", {"cngOvr": 3}),
+    ("HEAT", {"cngOvr": 1}),  # case-insensitive
+])
+async def test_thm_set_hvac_mode(thm_with_patch, mode, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_hvac_mode(mode)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", ["warm", "", "auto ", None, 1])
+async def test_thm_set_hvac_mode_invalid(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_hvac_mode(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# THM: set_away_mode (away 0/1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("enabled,expected", [
+    (True, {"away": 1}),
+    (False, {"away": 0}),
+])
+async def test_thm_set_away_mode(thm_with_patch, enabled, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_away_mode(enabled)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [1, 0, "true", None])
+async def test_thm_set_away_mode_invalid(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_mode(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# THM: set_fan_mode (fnMode 0=Off 1=On 2=Intermittent)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("mode,expected", [
+    ("off", {"fnMode": 0}),
+    ("on", {"fnMode": 1}),
+    ("intermittent", {"fnMode": 2}),
+    ("Intermittent", {"fnMode": 2}),
+])
+async def test_thm_set_fan_mode(thm_with_patch, mode, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_fan_mode(mode)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", ["auto", "", None, 1])
+async def test_thm_set_fan_mode_invalid(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_fan_mode(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# THM: set_target_temperature ({"target": {"value": int_F}})
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("temp_f,expected_value", [
+    (35, 35),
+    (68, 68),
+    (72, 72),
+    (99, 99),
+    (68.4, 68),  # rounds down
+    (68.6, 69),  # rounds up
+])
+async def test_thm_set_target_temperature(thm_with_patch, temp_f, expected_value):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_target_temperature(Temperature(temp_f, "F"))
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {"target": {"value": expected_value}}
+
+
+@pytest.mark.set_params
+async def test_thm_set_target_temperature_celsius_input(thm_with_patch):
+    """Celsius inputs should be converted to °F before being sent."""
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_target_temperature(Temperature(20, "C"))  # 68°F
+
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {"target": {"value": 68}}
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad_temp_f", [34, 100, 0, 200])
+async def test_thm_set_target_temperature_out_of_range(thm_with_patch, bad_temp_f):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_target_temperature(Temperature(bad_temp_f, "F"))
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [70, 70.5, "70", None])
+async def test_thm_set_target_temperature_wrong_type(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_target_temperature(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# ZON: set_app_button (aBut 0/1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("enabled,expected", [
+    (True, {"aBut": 1}),
+    (False, {"aBut": 0}),
+])
+async def test_zon_set_app_button(zon_with_patch, enabled, expected):
+    sensorlinx, device, mock_patch = zon_with_patch
+
+    await device.set_app_button(enabled)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [1, 0, "on", None])
+async def test_zon_set_app_button_invalid(zon_with_patch, bad):
+    _, device, mock_patch = zon_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_app_button(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# ZON: set_aux_setpoint (dhwT int °F)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("temp_f,expected_value", [
+    (33, 33),
+    (90, 90),
+    (140, 140),
+    (180, 180),
+    (140.4, 140),
+    (140.6, 141),
+])
+async def test_zon_set_aux_setpoint(zon_with_patch, temp_f, expected_value):
+    sensorlinx, device, mock_patch = zon_with_patch
+
+    await device.set_aux_setpoint(Temperature(temp_f, "F"))
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {"dhwT": expected_value}
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad_temp_f", [32, 181, -10, 500])
+async def test_zon_set_aux_setpoint_out_of_range(zon_with_patch, bad_temp_f):
+    _, device, mock_patch = zon_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_aux_setpoint(Temperature(bad_temp_f, "F"))
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [120, "120", None])
+async def test_zon_set_aux_setpoint_wrong_type(zon_with_patch, bad):
+    _, device, mock_patch = zon_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_aux_setpoint(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# patch_device low-level setter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+async def test_patch_device_sends_flat_json():
+    sensorlinx, mock_patch = _patched_sensorlinx()
+
+    await sensorlinx.patch_device("b1", "d1", cngOvr=1, away=0)
+
+    assert mock_patch.call_count == 1
+    args, kwargs = mock_patch.call_args
+    # URL is the first positional arg
+    assert "b1" in args[0] and "d1" in args[0]
+    assert kwargs["json"] == {"cngOvr": 1, "away": 0}
+
+
+@pytest.mark.set_params
+async def test_patch_device_requires_ids():
+    sensorlinx, mock_patch = _patched_sensorlinx()
+
+    with pytest.raises(InvalidParameterError):
+        await sensorlinx.patch_device("", "d1", cngOvr=1)
+    with pytest.raises(InvalidParameterError):
+        await sensorlinx.patch_device("b1", "", cngOvr=1)
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+async def test_patch_device_requires_fields():
+    sensorlinx, mock_patch = _patched_sensorlinx()
+
+    with pytest.raises(InvalidParameterError):
+        await sensorlinx.patch_device("b1", "d1")
+    assert mock_patch.call_count == 0


### PR DESCRIPTION
## Summary

Adds write setters for THM and ZON devices, completing the foundation for the
upcoming `hass_hbxcontrols 2.5.0b1` beta which will ship a real `climate`
entity (HVAC mode, target temperature, fan mode, away preset) plus a ZON
app-button switch and aux-setpoint number entity.

## Confirmed write field mappings

All raw HBX field names below were derived from paired before/after device
dumps captured by @eelton on a live install (9× THM-0600 fw 1.22 + 3×
ZON-0600 fw 1.32) — the diffs unambiguously identified which integer field
the cloud writes for each surface.

### THM (`ThmDevice`)
| New setter | HBX field | Notes |
|---|---|---|
| `set_hvac_mode("auto"\|"heat"\|"cool"\|"off")` | `cngOvr` | int 0/1/2/3 |
| `set_away_mode(bool)` | `away` | int 0/1 |
| `set_fan_mode("off"\|"on"\|"intermittent")` | `fnMode` | int 0/1/2 |
| `set_target_temperature(Temperature)` | `{target: {value: int_F}}` | shape inferred — see "Open uncertainty" |

### ZON (`ZonDevice`)
| New setter | HBX field | Notes |
|---|---|---|
| `set_app_button(bool)` | `aBut` | int 0/1; flips relay 12 server-side |
| `set_aux_setpoint(Temperature)` | `dhwT` | int °F (same field ECO uses for DHW target) |

## Implementation

* New low-level `Sensorlinx.patch_device(building_id, device_id, **fields)`
  for arbitrary raw field writes against the device-parameter endpoint.
  Reuses the same auth + 401 retry path as `set_device_parameter`.
* `ThmDevice` and `ZonDevice` setters validate input types/ranges, map enum
  strings to the correct integer values, and delegate to `patch_device`.
* All setters raise `InvalidParameterError` for bad input *before* making
  any HTTP call.

## Validation

* 61 new unit tests in `tests/thm_zon_setters_test.py` covering happy
  paths, enum mapping, range checks, type checks, and the low-level
  `patch_device` shape.
* Full suite: **855 passed, 18 skipped** locally.
* No changes to existing setters; no breakage of read-side accessors.

## Open uncertainty

`set_target_temperature` writes `{"target": {"value": int_F}}`. This shape
is inferred — in eelton's dumps, when he changed the heat setpoint by ±5°F,
only the derived nested `target.value` block moved; no raw schedule/mode
field changed. The two reasonable interpretations are (a) HBX accepts the
nested write directly, or (b) there's an override field that doesn't surface
in reads. We're shipping (a) first; if HBX returns a 4xx during eelton's
validation, we'll iterate the field name in 0.4.1.

## Versioning

* Bumps `0.3.1 → 0.4.0` (`pyproject.toml`).
* Auto-merge will be enabled and the standard watcher started after this PR
  opens; the release workflow tags + publishes to PyPI on green main.

## Next

Once `pysensorlinx 0.4.0` is on PyPI, `hass_hbxcontrols 2.5.0b1` will land
the consumer side: real `climate.<thm>` entity, `switch.<zon>_app_button`,
`number.<zon>_aux_setpoint`, and additional read entities for the fields
the library now decodes.
