### PR TITLE
fix: THM target temperature writes rmT/rmCT (not target.value)

### DIFF
--- a/src/pysensorlinx/__init__.py
+++ b/src/pysensorlinx/__init__.py
@@ -33,4 +33,4 @@ __all__ = [
     "NoTokenError",
     "InvalidParameterError",
 ]
-__version__ = "0.3.0"
+__version__ = "0.4.1"

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -109,7 +109,8 @@ PUMP_MODES = {
 THM_CHANGEOVER = "cngOvr"      # 0=Auto, 1=Heat, 2=Cool, 3=Off
 THM_AWAY = "away"              # 0=off, 1=on
 THM_FAN_MODE = "fnMode"        # 0=Off, 1=On, 2=Intermittent
-THM_TARGET = "target"          # nested object {"value": int_F} for setpoint
+THM_HEAT_SETPOINT = "rmT"      # int °F — heat-mode room setpoint
+THM_COOL_SETPOINT = "rmCT"     # int °F — cool-mode room setpoint
 ZON_APP_BUTTON = "aBut"        # 0=off, 1=on
 ZON_DHW_TARGET = "dhwT"        # int °F (auxiliary heat / DHW setpoint)
 # ZON aux setpoint reuses the same `dhwT` key as ECO DHW target (see DHW_TARGET_TEMP).
@@ -3118,26 +3119,25 @@ class ThmDevice(SensorlinxDevice):
         """
         Set the THM target setpoint for the active changeover (heat or cool).
 
-        The HBX backend determines which underlying field is updated based on
-        the current changeover state: when the THM is in Heat mode this
-        becomes the heat setpoint; in Cool mode it becomes the cool setpoint.
-        Calling this while the THM is in Off mode is rejected by the cloud.
+        Inspects the device's current ``target.type`` and writes either the
+        ``rmT`` (heat) or ``rmCT`` (cool) field accordingly. The HBX cloud
+        rejects setpoint writes when the THM is in Off mode.
 
         Args:
             value: A :class:`Temperature` in the 35°F–99°F range.
 
         Raises:
             InvalidParameterError: If ``value`` is not a Temperature or is
-                outside the safe range.
+                outside the safe range, or if the THM is currently Off.
             LoginError: If authentication fails.
             RuntimeError: If the API call fails for other reasons.
 
         Note:
-            The payload shape (``{"target": {"value": int_F}}``) is inferred
-            from read-side dumps; if HBX rejects this with a 4xx the
-            implementation should be revisited. See
-            ``files/multi-replica-validation-loop.md`` for the field-mapping
-            history.
+            Field mapping (``rmT`` / ``rmCT``) was confirmed via paired
+            before/after device dumps from a live THM-0600 (firmware 1.22)
+            on 2026-04-26: changing the heat setpoint moved ``rmT``;
+            changing the cool setpoint moved ``rmCT``. The previously-used
+            ``target.value`` was a derived read-only block.
         """
         if not isinstance(value, Temperature):
             _LOGGER.error(
@@ -3156,10 +3156,23 @@ class ThmDevice(SensorlinxDevice):
             raise InvalidParameterError(
                 "THM target temperature must be between 35°F and 99°F."
             )
+        info = await self._resolve_device_info(None)
+        target = info.get("target") or {}
+        target_type = target.get("type")
+        if target.get("isOff") or target_type not in ("heat", "cooling"):
+            _LOGGER.error(
+                "Cannot set THM target temperature while changeover is Off "
+                "(target.type=%r, target.isOff=%r).",
+                target_type, target.get("isOff"),
+            )
+            raise InvalidParameterError(
+                "Cannot set THM target temperature while changeover is Off."
+            )
+        field = THM_HEAT_SETPOINT if target_type == "heat" else THM_COOL_SETPOINT
         await self.sensorlinx.patch_device(
             self.building_id,
             self.device_id,
-            **{THM_TARGET: {"value": int(round(temp_f))}},
+            **{field: int(round(temp_f))},
         )
 
     async def _resolve_device_info(

--- a/tests/thm_zon_setters_test.py
+++ b/tests/thm_zon_setters_test.py
@@ -157,8 +157,13 @@ async def test_thm_set_fan_mode_invalid(thm_with_patch, bad):
 
 
 # ---------------------------------------------------------------------------
-# THM: set_target_temperature ({"target": {"value": int_F}})
+# THM: set_target_temperature — writes rmT (heat) or rmCT (cool) based on
+# the current changeover state. Confirmed against live THM dumps 2026-04-26.
 # ---------------------------------------------------------------------------
+
+def _device_info(target_type, is_off=False):
+    return {"target": {"type": target_type, "isOff": is_off}}
+
 
 @pytest.mark.set_params
 @pytest.mark.parametrize("temp_f,expected_value", [
@@ -169,25 +174,65 @@ async def test_thm_set_fan_mode_invalid(thm_with_patch, bad):
     (68.4, 68),  # rounds down
     (68.6, 69),  # rounds up
 ])
-async def test_thm_set_target_temperature(thm_with_patch, temp_f, expected_value):
+async def test_thm_set_target_temperature_heat_mode(thm_with_patch, temp_f, expected_value):
     sensorlinx, device, mock_patch = thm_with_patch
+    sensorlinx.get_devices = AsyncMock(return_value=_device_info("heat"))
 
     await device.set_target_temperature(Temperature(temp_f, "F"))
 
     assert mock_patch.call_count == 1
     _, kwargs = mock_patch.call_args
-    assert kwargs["json"] == {"target": {"value": expected_value}}
+    assert kwargs["json"] == {"rmT": expected_value}
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("temp_f,expected_value", [
+    (35, 35),
+    (79, 79),
+    (84, 84),
+    (99, 99),
+])
+async def test_thm_set_target_temperature_cool_mode(thm_with_patch, temp_f, expected_value):
+    sensorlinx, device, mock_patch = thm_with_patch
+    sensorlinx.get_devices = AsyncMock(return_value=_device_info("cooling"))
+
+    await device.set_target_temperature(Temperature(temp_f, "F"))
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {"rmCT": expected_value}
 
 
 @pytest.mark.set_params
 async def test_thm_set_target_temperature_celsius_input(thm_with_patch):
     """Celsius inputs should be converted to °F before being sent."""
     sensorlinx, device, mock_patch = thm_with_patch
+    sensorlinx.get_devices = AsyncMock(return_value=_device_info("heat"))
 
     await device.set_target_temperature(Temperature(20, "C"))  # 68°F
 
     _, kwargs = mock_patch.call_args
-    assert kwargs["json"] == {"target": {"value": 68}}
+    assert kwargs["json"] == {"rmT": 68}
+
+
+@pytest.mark.set_params
+async def test_thm_set_target_temperature_off_mode_rejected(thm_with_patch):
+    sensorlinx, device, mock_patch = thm_with_patch
+    sensorlinx.get_devices = AsyncMock(return_value=_device_info("heat", is_off=True))
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_target_temperature(Temperature(70, "F"))
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+async def test_thm_set_target_temperature_unknown_target_type_rejected(thm_with_patch):
+    sensorlinx, device, mock_patch = thm_with_patch
+    sensorlinx.get_devices = AsyncMock(return_value={"target": {}})
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_target_temperature(Temperature(70, "F"))
+    assert mock_patch.call_count == 0
 
 
 @pytest.mark.set_params


### PR DESCRIPTION
## Fix THM target temperature → write `rmT` / `rmCT`

`0.4.0`'s `ThmDevice.set_target_temperature` patched
`{"target": {"value": int}}`, inferred from read-side dumps. Live testing
on a THM-0600 (4-zone fleet) confirmed the API silently no-ops that
shape — `target` is a derived block, not writeable.

Fresh diff dumps show the actual writeable fields are top-level
integers:

* heat-mode setpoint: **`rmT`** (e.g. 67 → 72 when increased 5°F)
* cool-mode setpoint: **`rmCT`** (e.g. 79 → 84 when increased 5°F)

`set_target_temperature` now reads the device's current `target.type`
to dispatch to the right key, and rejects writes when changeover is
Off (which the cloud rejects anyway).

All other 0.4.0 setters (HVAC mode, away, fan mode, ZON app button,
ZON aux setpoint) were verified working in the same test session, so
no other changes.

* New tests: heat mode, cool mode, Celsius input, off-mode rejection,
  unknown-target-type rejection. Existing range/type-validation tests
  preserved.
* Full suite: **861 passed, 18 skipped**.
