### PR TITLE
Add THM schedule and humidity setters (0.5.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysensorlinx"          
-version = "0.4.2"             
+version = "0.5.0"             
 description = "Python library for accessing SensorLinx Device Data"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pysensorlinx/__init__.py
+++ b/src/pysensorlinx/__init__.py
@@ -33,4 +33,4 @@ __all__ = [
     "NoTokenError",
     "InvalidParameterError",
 ]
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -111,6 +111,9 @@ THM_AWAY = "away"              # 0=off, 1=on
 THM_FAN_MODE = "fnMode"        # 0=Off, 1=On, 2=Intermittent
 THM_HEAT_SETPOINT = "rmT"      # int °F — heat-mode room setpoint
 THM_COOL_SETPOINT = "rmCT"     # int °F — cool-mode room setpoint
+THM_SCHEDULE_ENABLE = "pgmble" # 0=schedule disabled, 1=schedule enabled
+THM_HUMIDITY_MODE = "useHum"   # 0=off, 1=on, 2=auto
+THM_HUMIDITY_TARGET = "hmT"    # int % relative humidity (0-100)
 ZON_APP_BUTTON = "aBut"        # 0=off, 1=on
 ZON_DHW_TARGET = "dhwT"        # int °F (auxiliary heat / DHW setpoint)
 # ZON aux setpoint reuses the same `dhwT` key as ECO DHW target (see DHW_TARGET_TEMP).
@@ -126,6 +129,12 @@ THM_FAN_MODE_VALUES = {
     "off": 0,
     "on": 1,
     "intermittent": 2,
+}
+
+THM_HUMIDITY_MODE_VALUES = {
+    "off": 0,
+    "on": 1,
+    "auto": 2,
 }
 
 CONF_SITE_NAME = "site_name"       # The name of the site (e.g., "home")
@@ -3173,6 +3182,110 @@ class ThmDevice(SensorlinxDevice):
             self.building_id,
             self.device_id,
             **{field: int(round(temp_f))},
+        )
+
+    async def set_schedule_enabled(self, enabled: bool) -> None:
+        """
+        Enable or disable the THM's on-device program/schedule.
+
+        Writes the ``pgmble`` field. When the schedule is disabled, the THM
+        ignores its weekday/weekend program and holds the manual setpoint;
+        when enabled, the program drives the active setpoint.
+
+        Args:
+            enabled: ``True`` to enable the schedule; ``False`` to disable it.
+
+        Raises:
+            InvalidParameterError: If ``enabled`` is not a bool.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+
+        Note:
+            Field name confirmed via paired before/after device dumps
+            from a live THM-0600 on 2026-04-28: toggling the schedule
+            moved ``pgmble`` between 0 and 1.
+        """
+        if not isinstance(enabled, bool):
+            _LOGGER.error(
+                "THM schedule enabled must be a boolean (got %r).", type(enabled)
+            )
+            raise InvalidParameterError("THM schedule enabled must be a boolean.")
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_SCHEDULE_ENABLE: 1 if enabled else 0},
+        )
+
+    async def set_humidity_mode(self, mode: str) -> None:
+        """
+        Set the THM humidity control mode.
+
+        Writes the ``useHum`` field. ``"off"`` disables humidity control,
+        ``"on"`` runs continuously toward :attr:`humidity target <set_humidity_target>`,
+        and ``"auto"`` lets the THM choose based on outdoor conditions.
+
+        Args:
+            mode: One of ``"off"``, ``"on"``, ``"auto"``.
+
+        Raises:
+            InvalidParameterError: If ``mode`` is not recognised.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+
+        Note:
+            Field mapping confirmed via paired before/after dumps from
+            a live THM-0600 on 2026-04-28: off→on moved ``useHum`` 0→1,
+            on→auto moved it 1→2.
+        """
+        key = mode.lower() if isinstance(mode, str) else None
+        if key not in THM_HUMIDITY_MODE_VALUES:
+            _LOGGER.error(
+                "Invalid THM humidity mode %r. Must be one of %s.",
+                mode, list(THM_HUMIDITY_MODE_VALUES),
+            )
+            raise InvalidParameterError(
+                "Invalid THM humidity mode. Must be 'off', 'on' or 'auto'."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_HUMIDITY_MODE: THM_HUMIDITY_MODE_VALUES[key]},
+        )
+
+    async def set_humidity_target(self, value: int) -> None:
+        """
+        Set the THM humidity target (relative humidity, percent).
+
+        Writes the ``hmT`` field as an integer percent in the 0-100 range.
+
+        Args:
+            value: Target relative humidity, 0-100 (integer).
+
+        Raises:
+            InvalidParameterError: If ``value`` is not an int or is out of range.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+
+        Note:
+            Field mapping confirmed via paired before/after dumps from a
+            live THM-0600 on 2026-04-28: changing the humidity target
+            from 40% to 45% moved ``hmT`` 40→45.
+        """
+        # Reject bool because bool is a subclass of int in Python.
+        if isinstance(value, bool) or not isinstance(value, int):
+            _LOGGER.error("THM humidity target must be an int (got %r).", type(value))
+            raise InvalidParameterError("THM humidity target must be an int.")
+        if not (0 <= value <= 100):
+            _LOGGER.error(
+                "THM humidity target must be between 0 and 100 (got %s).", value
+            )
+            raise InvalidParameterError(
+                "THM humidity target must be between 0 and 100."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{THM_HUMIDITY_TARGET: value},
         )
 
     async def _resolve_device_info(

--- a/tests/thm_zon_setters_test.py
+++ b/tests/thm_zon_setters_test.py
@@ -256,6 +256,112 @@ async def test_thm_set_target_temperature_wrong_type(thm_with_patch, bad):
 
 
 # ---------------------------------------------------------------------------
+# THM: set_schedule_enabled (pgmble 0/1)
+# Field mapping confirmed via paired before/after dumps from a live
+# THM-0600 on 2026-04-28: schedule off->on moved pgmble 0->1.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("enabled,expected", [
+    (True, {"pgmble": 1}),
+    (False, {"pgmble": 0}),
+])
+async def test_thm_set_schedule_enabled(thm_with_patch, enabled, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_schedule_enabled(enabled)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [1, 0, "true", None])
+async def test_thm_set_schedule_enabled_invalid(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_schedule_enabled(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# THM: set_humidity_mode (useHum 0=off 1=on 2=auto)
+# Field mapping confirmed via paired before/after dumps on 2026-04-28.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("mode,expected", [
+    ("off", {"useHum": 0}),
+    ("on", {"useHum": 1}),
+    ("auto", {"useHum": 2}),
+    ("Auto", {"useHum": 2}),  # case-insensitive
+])
+async def test_thm_set_humidity_mode(thm_with_patch, mode, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_humidity_mode(mode)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", ["enabled", "", None, 1, "off "])
+async def test_thm_set_humidity_mode_invalid(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_humidity_mode(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# THM: set_humidity_target (hmT integer percent, 0-100)
+# Field mapping confirmed via paired before/after dumps on 2026-04-28
+# (40% -> 45% moved hmT 40 -> 45).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("value,expected", [
+    (0, {"hmT": 0}),
+    (40, {"hmT": 40}),
+    (45, {"hmT": 45}),
+    (100, {"hmT": 100}),
+])
+async def test_thm_set_humidity_target(thm_with_patch, value, expected):
+    sensorlinx, device, mock_patch = thm_with_patch
+
+    await device.set_humidity_target(value)
+
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == expected
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [-1, 101, 200])
+async def test_thm_set_humidity_target_out_of_range(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_humidity_target(bad)
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [40.5, "40", None, True, False])
+async def test_thm_set_humidity_target_wrong_type(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+
+    with pytest.raises(InvalidParameterError):
+        await device.set_humidity_target(bad)
+    assert mock_patch.call_count == 0
+
+
+# ---------------------------------------------------------------------------
 # ZON: set_app_button (aBut 0/1)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds three setters on `ThmDevice` so the HA integration can wire up the schedule-enable toggle, humidity mode, and humidity target that eelton requested in `sslivins/hass_hbxcontrols#12`.

| Setter | Field | Values |
|---|---|---|
| `set_schedule_enabled(bool)` | `pgmble` | 0=off, 1=on |
| `set_humidity_mode(str)` | `useHum` | "off"/"on"/"auto" -> 0/1/2 |
| `set_humidity_target(int)` | `hmT` | percent, 0-100 |

## How field mappings were confirmed

Paired before/after JSON dumps from a live THM-0600 (firmware 1.22) on 2026-04-28 — same methodology used for `rmT`/`rmCT` in 0.4.0:

- Schedule off→on: `pgmble` 0 → 1
- Humidity off→on: `useHum` 0 → 1
- Humidity on→auto: `useHum` 1 → 2
- Humidity 40%→45%: `hmT` 40 → 45

## Tests

- 12 new parametrized tests in `tests/thm_zon_setters_test.py` covering happy path + bad input rejection (wrong type, out-of-range, non-bool ints, etc.).
- Full suite: 888 passed, 18 skipped.

## Version bump

`0.4.2` → `0.5.0` (new public API).
