### PR TITLE
feat: 0.5.1 - THM schedule/humidity setters + ZON sequence helper

### DIFF
--- a/src/pysensorlinx/__init__.py
+++ b/src/pysensorlinx/__init__.py
@@ -33,4 +33,4 @@ __all__ = [
     "NoTokenError",
     "InvalidParameterError",
 ]
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -3403,6 +3403,36 @@ class ZonDevice(SensorlinxDevice):
         raw = info.get("znID")
         return int(raw) if raw is not None else None
 
+    async def get_sequence(
+        self, device_info: Optional[Dict] = None
+    ) -> int:
+        """
+        Return the zone-block sequence offset for this controller.
+
+        The HBX system supports stacking up to five ZON controllers per
+        installation: one Primary (zones 1-4) plus up to four Secondary
+        units (zones 5-8, 9-12, 13-16, 17-20). Each device's place in
+        that stack is reported as an integer 0-4 in the ``sequence``
+        block (or, equivalently, as ``znSeq`` at the top level).
+
+        Multiplied by four and added to the relay slot index, this value
+        produces the absolute "zone number" the HBX mobile app shows to
+        the end user. For a Secondary unit at sequence 1 with relays at
+        idx 0/1/2 active, the app calls those Zone 5/6/7.
+
+        Returns 0 (Primary) when the field is absent or unparseable.
+        """
+        info = await self._resolve_device_info(device_info)
+        block = info.get("sequence")
+        if isinstance(block, dict):
+            raw = block.get("value")
+            if isinstance(raw, (int, float)):
+                return int(raw)
+        raw = info.get("znSeq")
+        if isinstance(raw, (int, float)):
+            return int(raw)
+        return 0
+
     async def get_temperatures(
         self,
         temp_name: Optional[str] = None,

--- a/tests/device_dispatch_test.py
+++ b/tests/device_dispatch_test.py
@@ -360,6 +360,50 @@ async def test_zon_zone_id(sensorlinx, zon_info):
 
 
 @pytest.mark.asyncio
+async def test_zon_get_sequence_primary(sensorlinx, zon_info):
+    """Fixture device is Primary (sequence.value=0), no zone offset."""
+    dev = ZonDevice(sensorlinx, "bld-1", "X")
+    assert await dev.get_sequence(zon_info) == 0
+
+
+@pytest.mark.asyncio
+async def test_zon_get_sequence_secondary_5_8(sensorlinx, zon_info):
+    """Validates sequence=1 (range 5-8) — matches eelton hbxtesting3 dump #1."""
+    dev = ZonDevice(sensorlinx, "bld-1", "X")
+    info = dict(zon_info)
+    info["sequence"] = {"value": 1, "name": "Secondary", "range": "5-8"}
+    info["znSeq"] = 1
+    assert await dev.get_sequence(info) == 1
+
+
+@pytest.mark.asyncio
+async def test_zon_get_sequence_secondary_9_12(sensorlinx, zon_info):
+    """Validates sequence=2 (range 9-12) — matches eelton hbxtesting3 dump #2."""
+    dev = ZonDevice(sensorlinx, "bld-1", "X")
+    info = dict(zon_info)
+    info["sequence"] = {"value": 2, "name": "Secondary", "range": "9-12"}
+    info["znSeq"] = 2
+    assert await dev.get_sequence(info) == 2
+
+
+@pytest.mark.asyncio
+async def test_zon_get_sequence_falls_back_to_znseq(sensorlinx, zon_info):
+    """When sequence block is missing, fall back to top-level znSeq."""
+    dev = ZonDevice(sensorlinx, "bld-1", "X")
+    info = dict(zon_info)
+    info.pop("sequence", None)
+    info["znSeq"] = 3
+    assert await dev.get_sequence(info) == 3
+
+
+@pytest.mark.asyncio
+async def test_zon_get_sequence_defaults_to_zero(sensorlinx):
+    """When both sequence and znSeq are absent, default to Primary (0)."""
+    dev = ZonDevice(sensorlinx, "bld-1", "X")
+    assert await dev.get_sequence({}) == 0
+
+
+@pytest.mark.asyncio
 async def test_zon_name(sensorlinx, zon_info):
     dev = ZonDevice(sensorlinx, "bld-1", "X")
     assert await dev.get_name(zon_info) == "AZON-0224"


### PR DESCRIPTION
# pysensorlinx 0.4.2 → 0.5.1: THM schedule/humidity setters + ZON sequence

Bundled release containing the unmerged 0.5.0 work plus a small 0.5.1 addition.

## What's in 0.5.0 (carried forward from earlier work on this branch)

- `ThmDevice.set_schedule_enabled(bool)` and `get_schedule_enabled()`
- `ThmDevice.set_humidity_*` setters and getters

## What's new in 0.5.1

- `ZonDevice.get_sequence(device_info) -> int` — returns the
  zone-controller's sequence position in a stacked install.
  - Reads `sequence.value` (primary), falls back to legacy top-level
    `znSeq`, falls back to `0`.
  - Lets consumers (hass_hbxcontrols) compute the HBX app's absolute
    zone numbering: `zone_number = seq * 4 + idx + 1` for active relays.
  - 5 new tests in `tests/device_dispatch_test.py`.

## Why ship as 0.5.1 instead of stacked under 0.5.0

Keeps the schedule/humidity feature set (0.5.0) distinct from the
sequence helper (0.5.1) in changelog/audit, even though they ship in
one release. `hass_hbxcontrols` 2.5.0b8 pins `pysensorlinx==0.5.1`.

## Tests

- 54 passed (49 prior + 5 new), no regressions.

## Linked

- Reported in https://github.com/sslivins/hass_hbxcontrols/issues/12
- Consumed by hass_hbxcontrols 2.5.0b8.
