### PR TITLE
feat: THM away-mode setpoint accessors (0.5.3)

### DIFF
--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -111,6 +111,15 @@ THM_AWAY = "away"              # 0=off, 1=on
 THM_FAN_MODE = "fnMode"        # 0=Off, 1=On, 2=Intermittent
 THM_HEAT_SETPOINT = "rmT"      # int °F — heat-mode room setpoint
 THM_COOL_SETPOINT = "rmCT"     # int °F — cool-mode room setpoint
+# Away-mode setpoints live in a nested object under `awayMode`. Unlike rmT/rmCT,
+# these are only the active setpoints when the THM Away preset is on. Field
+# paths confirmed via paired before/after dumps from a live THM-0600 on
+# 2026-05-01: in away mode, baseline awayMode.heatTarget.value=53 / coolTarget=87,
+# then +5°F each via the app popup → 58 / 92.
+THM_AWAY_MODE = "awayMode"
+THM_AWAY_HEAT_TARGET = "heatTarget"
+THM_AWAY_COOL_TARGET = "coolTarget"
+THM_AWAY_TARGET_VALUE = "value"
 THM_SCHEDULE_ENABLE = "pgmble" # 0=schedule disabled, 1=schedule enabled
 THM_HUMIDITY_MODE = "useHum"   # 0=off, 1=on, 2=auto
 THM_HUMIDITY_TARGET = "hmT"    # int % relative humidity (0-100)
@@ -3448,6 +3457,147 @@ class ThmDevice(SensorlinxDevice):
             **{
                 THM_HEAT_SETPOINT: heat_int,
                 THM_COOL_SETPOINT: cool_int,
+            },
+        )
+
+    async def get_away_heat_setpoint(
+        self, device_info: Optional[Dict] = None
+    ) -> Optional[Temperature]:
+        """
+        Return the away-mode heat setpoint in °F.
+
+        Reads the nested ``awayMode.heatTarget.value`` field. This is the
+        active heat target only while the THM Away preset is on; in Home
+        mode the active heat target is ``rmT`` (see
+        :py:meth:`get_heat_setpoint`).
+
+        Returns:
+            ``Temperature`` in °F, or ``None`` when the field is missing.
+
+        Note:
+            Field path confirmed via paired before/after dumps from a
+            live THM-0600 on 2026-05-01: changing the away heat setpoint
+            in the HBX app's away-temps popup moved
+            ``awayMode.heatTarget.value`` from 53 to 58.
+        """
+        info = await self._resolve_device_info(device_info)
+        block = info.get(THM_AWAY_MODE) or {}
+        target = block.get(THM_AWAY_HEAT_TARGET) or {}
+        value = target.get(THM_AWAY_TARGET_VALUE)
+        if value is None:
+            return None
+        return Temperature(value, "F")
+
+    async def get_away_cool_setpoint(
+        self, device_info: Optional[Dict] = None
+    ) -> Optional[Temperature]:
+        """
+        Return the away-mode cool setpoint in °F.
+
+        Mirror of :py:meth:`get_away_heat_setpoint` for the cool side,
+        reading ``awayMode.coolTarget.value``.
+
+        Returns:
+            ``Temperature`` in °F, or ``None`` when the field is missing.
+        """
+        info = await self._resolve_device_info(device_info)
+        block = info.get(THM_AWAY_MODE) or {}
+        target = block.get(THM_AWAY_COOL_TARGET) or {}
+        value = target.get(THM_AWAY_TARGET_VALUE)
+        if value is None:
+            return None
+        return Temperature(value, "F")
+
+    async def set_away_heat_setpoint(self, value: Temperature) -> None:
+        """
+        Set the away-mode heat setpoint (``awayMode.heatTarget.value``).
+
+        Sends a partial-nested PATCH so the cool side is preserved.
+
+        Args:
+            value: A :class:`Temperature` in the 35°F–99°F range.
+
+        Raises:
+            InvalidParameterError: If ``value`` is invalid.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        temp_int = self._validate_setpoint(value, "away heat")
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{
+                THM_AWAY_MODE: {
+                    THM_AWAY_HEAT_TARGET: {THM_AWAY_TARGET_VALUE: temp_int},
+                },
+            },
+        )
+
+    async def set_away_cool_setpoint(self, value: Temperature) -> None:
+        """
+        Set the away-mode cool setpoint (``awayMode.coolTarget.value``).
+
+        Mirror of :py:meth:`set_away_heat_setpoint`.
+
+        Args:
+            value: A :class:`Temperature` in the 35°F–99°F range.
+
+        Raises:
+            InvalidParameterError: If ``value`` is invalid.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        temp_int = self._validate_setpoint(value, "away cool")
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{
+                THM_AWAY_MODE: {
+                    THM_AWAY_COOL_TARGET: {THM_AWAY_TARGET_VALUE: temp_int},
+                },
+            },
+        )
+
+    async def set_away_heat_cool_setpoints(
+        self, heat: Temperature, cool: Temperature
+    ) -> None:
+        """
+        Set both away-mode heat and cool setpoints in a single PATCH.
+
+        Use this for atomic dual-setpoint writes to the away preset to
+        avoid the transient inconsistent state two sequential PATCHes
+        would produce.
+
+        Args:
+            heat: Away-side heat ``Temperature`` (35°F–99°F).
+            cool: Away-side cool ``Temperature`` (35°F–99°F). Must be
+                strictly greater than ``heat``.
+
+        Raises:
+            InvalidParameterError: If either value is invalid or
+                ``heat >= cool``.
+            LoginError: If authentication fails.
+            RuntimeError: If the API call fails for other reasons.
+        """
+        heat_int = self._validate_setpoint(heat, "away heat")
+        cool_int = self._validate_setpoint(cool, "away cool")
+        if heat_int >= cool_int:
+            _LOGGER.error(
+                "THM away heat setpoint (%s°F) must be lower than away cool "
+                "setpoint (%s°F).",
+                heat_int, cool_int,
+            )
+            raise InvalidParameterError(
+                "THM away heat setpoint must be lower than away cool setpoint."
+            )
+        await self.sensorlinx.patch_device(
+            self.building_id,
+            self.device_id,
+            **{
+                THM_AWAY_MODE: {
+                    THM_AWAY_HEAT_TARGET: {THM_AWAY_TARGET_VALUE: heat_int},
+                    THM_AWAY_COOL_TARGET: {THM_AWAY_TARGET_VALUE: cool_int},
+                },
             },
         )
 

--- a/tests/thm_zon_setters_test.py
+++ b/tests/thm_zon_setters_test.py
@@ -628,3 +628,134 @@ async def test_thm_get_active_demands_missing_field(thm_with_patch):
     _, device, _ = thm_with_patch
     result = await device.get_active_demands({})
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# THM 0.5.3: get/set away-mode setpoints (awayMode.heatTarget.value etc.)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("payload,expected_f", [
+    ({"awayMode": {"heatTarget": {"value": 53}}}, 53),
+    ({"awayMode": {"heatTarget": {"value": 58}}}, 58),
+])
+async def test_thm_get_away_heat_setpoint(thm_with_patch, payload, expected_f):
+    _, device, _ = thm_with_patch
+    result = await device.get_away_heat_setpoint(payload)
+    assert result is not None
+    assert result.to_fahrenheit() == expected_f
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"awayMode": {}},
+    {"awayMode": {"heatTarget": {}}},
+    {"awayMode": {"heatTarget": {"value": None}}},
+])
+async def test_thm_get_away_heat_setpoint_missing(thm_with_patch, payload):
+    _, device, _ = thm_with_patch
+    result = await device.get_away_heat_setpoint(payload)
+    assert result is None
+
+
+@pytest.mark.parametrize("payload,expected_f", [
+    ({"awayMode": {"coolTarget": {"value": 87}}}, 87),
+    ({"awayMode": {"coolTarget": {"value": 92}}}, 92),
+])
+async def test_thm_get_away_cool_setpoint(thm_with_patch, payload, expected_f):
+    _, device, _ = thm_with_patch
+    result = await device.get_away_cool_setpoint(payload)
+    assert result is not None
+    assert result.to_fahrenheit() == expected_f
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"awayMode": {}},
+    {"awayMode": {"coolTarget": {}}},
+])
+async def test_thm_get_away_cool_setpoint_missing(thm_with_patch, payload):
+    _, device, _ = thm_with_patch
+    result = await device.get_away_cool_setpoint(payload)
+    assert result is None
+
+
+@pytest.mark.set_params
+async def test_thm_set_away_heat_setpoint(thm_with_patch):
+    _, device, mock_patch = thm_with_patch
+    await device.set_away_heat_setpoint(Temperature(58, "F"))
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    # Partial-nested PATCH so the cool side is preserved.
+    assert kwargs["json"] == {"awayMode": {"heatTarget": {"value": 58}}}
+
+
+@pytest.mark.set_params
+async def test_thm_set_away_cool_setpoint(thm_with_patch):
+    _, device, mock_patch = thm_with_patch
+    await device.set_away_cool_setpoint(Temperature(92, "F"))
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {"awayMode": {"coolTarget": {"value": 92}}}
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad_temp", [34, 100])
+async def test_thm_set_away_heat_setpoint_out_of_range(thm_with_patch, bad_temp):
+    _, device, mock_patch = thm_with_patch
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_heat_setpoint(Temperature(bad_temp, "F"))
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("bad", [None, 72, "72", 72.0])
+async def test_thm_set_away_heat_setpoint_wrong_type(thm_with_patch, bad):
+    _, device, mock_patch = thm_with_patch
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_heat_setpoint(bad)
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+async def test_thm_set_away_heat_cool_setpoints_single_patch(thm_with_patch):
+    _, device, mock_patch = thm_with_patch
+    await device.set_away_heat_cool_setpoints(
+        Temperature(58, "F"), Temperature(92, "F"),
+    )
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    assert kwargs["json"] == {
+        "awayMode": {
+            "heatTarget": {"value": 58},
+            "coolTarget": {"value": 92},
+        },
+    }
+
+
+@pytest.mark.set_params
+@pytest.mark.parametrize("heat,cool", [
+    (70, 70),
+    (75, 70),
+    (80, 79),
+])
+async def test_thm_set_away_heat_cool_setpoints_rejects_invalid_pair(thm_with_patch, heat, cool):
+    _, device, mock_patch = thm_with_patch
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_heat_cool_setpoints(
+            Temperature(heat, "F"), Temperature(cool, "F"),
+        )
+    assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+async def test_thm_set_away_heat_cool_setpoints_validates_each_side(thm_with_patch):
+    _, device, mock_patch = thm_with_patch
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_heat_cool_setpoints(
+            Temperature(34, "F"), Temperature(79, "F"),
+        )
+    with pytest.raises(InvalidParameterError):
+        await device.set_away_heat_cool_setpoints(
+            Temperature(67, "F"), Temperature(100, "F"),
+        )
+    assert mock_patch.call_count == 0


### PR DESCRIPTION
## Summary

Adds five new `ThmDevice` methods for the **away-preset** setpoints, which live in a separate nested object (`awayMode.heatTarget.value` / `awayMode.coolTarget.value`) from the home/comfort setpoints `rmT`/`rmCT`.

Driven by a downstream user report ([hass_hbxcontrols#12](https://github.com/sslivins/hass_hbxcontrols/issues/12)) that 0.5.2's setpoint writes worked in Home preset but were silently ignored in Away preset.

## API

| Method | Reads/writes |
|---|---|
| `get_away_heat_setpoint` | `awayMode.heatTarget.value` |
| `get_away_cool_setpoint` | `awayMode.coolTarget.value` |
| `set_away_heat_setpoint` | partial-nested PATCH on heat target |
| `set_away_cool_setpoint` | partial-nested PATCH on cool target |
| `set_away_heat_cool_setpoints` | atomic dual-PATCH (heat<cool validated) |

PATCH payload uses partial-nested form so each side is preserved when the other is updated:

```json
{"awayMode": {"heatTarget": {"value": 58}}}
```

## Field provenance

Confirmed via paired before/after device dumps from a live THM-0600 on 2026-05-01:

- **Baseline (away):** `awayMode.heatTarget.value = 53`, `awayMode.coolTarget.value = 87`
- **After +5°F to away heat via the HBX app's popup:** `heatTarget.value = 58` (cool unchanged)
- **After +5°F to away cool via the HBX app's popup:** `coolTarget.value = 92` (heat preserved)

## Validation

- 24 new tests covering reads, writes, missing-field handling, range validation, type validation, atomic dual-PATCH, and heat<cool deadband enforcement.
- Full suite: **958 passed** (was 934).
- Purely additive — no behavior change for existing accessors.

## Open question (cloud-side)

The PATCH shape is our best guess based on REST PATCH semantics; we haven't yet observed the cloud accepting it on a live device. If the live test from the downstream user reveals it doesn't persist, we'll iterate (e.g., full-block replacement instead of partial-nested).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
