### PR TITLE
feat: read-modify-write for THM away-mode setpoints (0.5.4)

### DIFF
--- a/src/pysensorlinx/sensorlinx.py
+++ b/src/pysensorlinx/sensorlinx.py
@@ -3508,11 +3508,37 @@ class ThmDevice(SensorlinxDevice):
             return None
         return Temperature(value, "F")
 
+    async def _load_away_mode_block(self) -> Dict:
+        """Fetch the current ``awayMode`` block for read-modify-write.
+
+        The cloud silently rejects partial-nested PATCHes that don't
+        include the full block (title/activated/pgm/heatTarget/
+        coolTarget), so every away-setpoint setter has to splice into a
+        complete copy. Returns a deep-ish copy of the existing block,
+        or a sane default if the device hasn't seeded one yet.
+        """
+        info = await self.sensorlinx.get_devices(self.building_id, self.device_id)
+        if not isinstance(info, dict):
+            info = {}
+        block = info.get(THM_AWAY_MODE)
+        if not isinstance(block, dict):
+            block = {}
+        # Shallow copy of the top-level block plus copies of the nested
+        # heatTarget/coolTarget so we can mutate them safely.
+        result = dict(block)
+        for key in (THM_AWAY_HEAT_TARGET, THM_AWAY_COOL_TARGET):
+            target = result.get(key)
+            result[key] = dict(target) if isinstance(target, dict) else {"enabled": True}
+        return result
+
     async def set_away_heat_setpoint(self, value: Temperature) -> None:
         """
         Set the away-mode heat setpoint (``awayMode.heatTarget.value``).
 
-        Sends a partial-nested PATCH so the cool side is preserved.
+        Performs a read-modify-write of the entire ``awayMode`` block:
+        the cloud silently rejects partial-nested PATCHes that omit
+        ``title``/``activated``/``pgm``/``coolTarget``, so the existing
+        block is fetched first and the new value spliced in.
 
         Args:
             value: A :class:`Temperature` in the 35°F–99°F range.
@@ -3523,21 +3549,20 @@ class ThmDevice(SensorlinxDevice):
             RuntimeError: If the API call fails for other reasons.
         """
         temp_int = self._validate_setpoint(value, "away heat")
+        block = await self._load_away_mode_block()
+        block[THM_AWAY_HEAT_TARGET][THM_AWAY_TARGET_VALUE] = temp_int
         await self.sensorlinx.patch_device(
             self.building_id,
             self.device_id,
-            **{
-                THM_AWAY_MODE: {
-                    THM_AWAY_HEAT_TARGET: {THM_AWAY_TARGET_VALUE: temp_int},
-                },
-            },
+            **{THM_AWAY_MODE: block},
         )
 
     async def set_away_cool_setpoint(self, value: Temperature) -> None:
         """
         Set the away-mode cool setpoint (``awayMode.coolTarget.value``).
 
-        Mirror of :py:meth:`set_away_heat_setpoint`.
+        Mirror of :py:meth:`set_away_heat_setpoint` — uses the same
+        read-modify-write strategy on the full ``awayMode`` block.
 
         Args:
             value: A :class:`Temperature` in the 35°F–99°F range.
@@ -3548,14 +3573,12 @@ class ThmDevice(SensorlinxDevice):
             RuntimeError: If the API call fails for other reasons.
         """
         temp_int = self._validate_setpoint(value, "away cool")
+        block = await self._load_away_mode_block()
+        block[THM_AWAY_COOL_TARGET][THM_AWAY_TARGET_VALUE] = temp_int
         await self.sensorlinx.patch_device(
             self.building_id,
             self.device_id,
-            **{
-                THM_AWAY_MODE: {
-                    THM_AWAY_COOL_TARGET: {THM_AWAY_TARGET_VALUE: temp_int},
-                },
-            },
+            **{THM_AWAY_MODE: block},
         )
 
     async def set_away_heat_cool_setpoints(
@@ -3566,7 +3589,7 @@ class ThmDevice(SensorlinxDevice):
 
         Use this for atomic dual-setpoint writes to the away preset to
         avoid the transient inconsistent state two sequential PATCHes
-        would produce.
+        would produce. Read-modify-write on the full ``awayMode`` block.
 
         Args:
             heat: Away-side heat ``Temperature`` (35°F–99°F).
@@ -3590,15 +3613,13 @@ class ThmDevice(SensorlinxDevice):
             raise InvalidParameterError(
                 "THM away heat setpoint must be lower than away cool setpoint."
             )
+        block = await self._load_away_mode_block()
+        block[THM_AWAY_HEAT_TARGET][THM_AWAY_TARGET_VALUE] = heat_int
+        block[THM_AWAY_COOL_TARGET][THM_AWAY_TARGET_VALUE] = cool_int
         await self.sensorlinx.patch_device(
             self.building_id,
             self.device_id,
-            **{
-                THM_AWAY_MODE: {
-                    THM_AWAY_HEAT_TARGET: {THM_AWAY_TARGET_VALUE: heat_int},
-                    THM_AWAY_COOL_TARGET: {THM_AWAY_TARGET_VALUE: cool_int},
-                },
-            },
+            **{THM_AWAY_MODE: block},
         )
 
     async def get_active_demands(

--- a/tests/thm_zon_setters_test.py
+++ b/tests/thm_zon_setters_test.py
@@ -24,7 +24,7 @@ from pysensorlinx import (
 from pysensorlinx.sensorlinx import ThmDevice, ZonDevice
 
 
-def _patched_sensorlinx():
+def _patched_sensorlinx(device_payload=None):
     sensorlinx = Sensorlinx()
     sensorlinx._session = MagicMock()
     sensorlinx._session.closed = False
@@ -39,6 +39,27 @@ def _patched_sensorlinx():
     mock_response.text = AsyncMock(return_value="{}")
     mock_patch = MagicMock(return_value=mock_response)
     sensorlinx._session.patch = mock_patch
+
+    # GET mock for read-modify-write setters (pysensorlinx 0.5.4+).
+    # Defaults to a complete awayMode block matching real HBX firmware.
+    if device_payload is None:
+        device_payload = {
+            "awayMode": {
+                "title": "Away",
+                "activated": True,
+                "pgm": 2,
+                "heatTarget": {"enabled": True, "value": 53},
+                "coolTarget": {"enabled": True, "value": 87},
+            },
+        }
+    get_response = MagicMock()
+    get_response.__aenter__ = AsyncMock(return_value=get_response)
+    get_response.__aexit__ = AsyncMock(return_value=None)
+    get_response.status = 200
+    get_response.headers = {"Content-Type": "application/json"}
+    get_response.json = AsyncMock(return_value=device_payload)
+    get_response.text = AsyncMock(return_value="{}")
+    sensorlinx._session.get = MagicMock(return_value=get_response)
     return sensorlinx, mock_patch
 
 
@@ -685,8 +706,18 @@ async def test_thm_set_away_heat_setpoint(thm_with_patch):
     await device.set_away_heat_setpoint(Temperature(58, "F"))
     assert mock_patch.call_count == 1
     _, kwargs = mock_patch.call_args
-    # Partial-nested PATCH so the cool side is preserved.
-    assert kwargs["json"] == {"awayMode": {"heatTarget": {"value": 58}}}
+    # Full-block PATCH (read-modify-write): the cloud silently ignores
+    # partial-nested PATCHes so we splice into a complete copy of the
+    # existing awayMode block.
+    assert kwargs["json"] == {
+        "awayMode": {
+            "title": "Away",
+            "activated": True,
+            "pgm": 2,
+            "heatTarget": {"enabled": True, "value": 58},
+            "coolTarget": {"enabled": True, "value": 87},
+        },
+    }
 
 
 @pytest.mark.set_params
@@ -695,7 +726,15 @@ async def test_thm_set_away_cool_setpoint(thm_with_patch):
     await device.set_away_cool_setpoint(Temperature(92, "F"))
     assert mock_patch.call_count == 1
     _, kwargs = mock_patch.call_args
-    assert kwargs["json"] == {"awayMode": {"coolTarget": {"value": 92}}}
+    assert kwargs["json"] == {
+        "awayMode": {
+            "title": "Away",
+            "activated": True,
+            "pgm": 2,
+            "heatTarget": {"enabled": True, "value": 53},
+            "coolTarget": {"enabled": True, "value": 92},
+        },
+    }
 
 
 @pytest.mark.set_params
@@ -726,8 +765,11 @@ async def test_thm_set_away_heat_cool_setpoints_single_patch(thm_with_patch):
     _, kwargs = mock_patch.call_args
     assert kwargs["json"] == {
         "awayMode": {
-            "heatTarget": {"value": 58},
-            "coolTarget": {"value": 92},
+            "title": "Away",
+            "activated": True,
+            "pgm": 2,
+            "heatTarget": {"enabled": True, "value": 58},
+            "coolTarget": {"enabled": True, "value": 92},
         },
     }
 
@@ -759,3 +801,21 @@ async def test_thm_set_away_heat_cool_setpoints_validates_each_side(thm_with_pat
             Temperature(67, "F"), Temperature(100, "F"),
         )
     assert mock_patch.call_count == 0
+
+
+@pytest.mark.set_params
+async def test_thm_set_away_heat_setpoint_seeds_block_when_missing():
+    """If the device dump has no ``awayMode`` block at all (older firmware
+    or a freshly-paired device that hasn't been to the away-popup yet), we
+    fall back to a minimal-but-valid block instead of raising."""
+    sensorlinx, mock_patch = _patched_sensorlinx(device_payload={"id": "thm456"})
+    device = ThmDevice(
+        sensorlinx=sensorlinx, building_id="building123", device_id="thm456",
+    )
+    await device.set_away_heat_setpoint(Temperature(58, "F"))
+    assert mock_patch.call_count == 1
+    _, kwargs = mock_patch.call_args
+    # heatTarget gets the new value, coolTarget gets a sane default shape.
+    body = kwargs["json"]
+    assert body["awayMode"]["heatTarget"] == {"enabled": True, "value": 58}
+    assert "coolTarget" in body["awayMode"]


### PR DESCRIPTION
## What

Read-modify-write the entire `awayMode` block instead of partial-nested PATCH.

## Why

0.5.3 sent partial-nested PATCHes like `{"awayMode": {"heatTarget": {"value": N}}}`. Five paired before/after dumps from a live THM on 2026-05-01 confirm those PATCHes reach the cloud (`changeSource="api"`) but the value never changes — the cloud silently drops anything that isn't a full `awayMode` block.

## How

- New `ThmDevice._load_away_mode_block()` fetches current state via `get_devices`.
- The three away setters splice the new value(s) into a copy of the existing block, then PATCH the whole block back. Mirrors what the HBX mobile app does.
- Cost: every away write is 2 round-trips (GET + PATCH). Acceptable for user-initiated UI.

## Tests

959 passed (was 958 — added missing-block fallback coverage). Extended `_patched_sensorlinx` to mock GET. Validation paths still skip both calls.
