### PR TITLE
ci: remove GITHUB_TOKEN fallback on VERSION_BUMP_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-          # GITHUB_TOKEN works if main is unprotected, or if
-          # github-actions[bot] is on the branch-protection bypass list.
-          # If main is PR-protected and the bot can't bypass, set the
-          # VERSION_BUMP_TOKEN secret (fine-grained PAT with contents:write).
-          token: ${{ secrets.VERSION_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          # Push the version bump via the shared VERSION_BUMP_TOKEN PAT
+          # (fine-grained, contents:write). No GITHUB_TOKEN fallback:
+          # fail loudly if the secret is missing rather than silently
+          # downgrading to github-actions[bot] and hiding the misconfig.
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
       - name: Bump patch version and push
         run: |


### PR DESCRIPTION
We now share a single fine-grained PAT (`VERSION_BUMP_TOKEN`) across all of our publishing repos (`agora`, `agora-cms`, `agora-os`, `pygemstone`, `pynapoleon`, `pyomnisense`, `pysensorlinx`).

The previous `|| secrets.GITHUB_TOKEN` fallback turned out to be hiding a year-long misconfiguration on `agora-cms`: the secret value was set but the actual auth was silently coming from `github-actions[bot]` via the fallback. The PAT showed `Never used` while we assumed it was working.

Removing the fallback so any future misconfig (missing secret, wrong value, expired PAT, repo not in the PAT's allow-list) fails loudly at the next release instead of being masked. `bump-main` is a non-critical post-publish step; failing it does not break the release itself, just stops the patch bump until the secret is fixed.